### PR TITLE
Autoremove reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ apt-update/apt-update
 docs
 tags
 _last_py2_res
+*.pyc
+.cache

--- a/landscape/message_schemas/server_bound.py
+++ b/landscape/message_schemas/server_bound.py
@@ -363,13 +363,15 @@ PACKAGES = Message(
      "available": package_ids_or_ranges,
      "available-upgrades": package_ids_or_ranges,
      "locked": package_ids_or_ranges,
+     "autoremovable": package_ids_or_ranges,
+     "not-autoremovable": package_ids_or_ranges,
      "not-installed": package_ids_or_ranges,
      "not-available": package_ids_or_ranges,
      "not-available-upgrades": package_ids_or_ranges,
      "not-locked": package_ids_or_ranges},
     optional=["installed", "available", "available-upgrades", "locked",
               "not-available", "not-installed", "not-available-upgrades",
-              "not-locked"])
+              "not-locked", "autoremovable", "not-autoremovable"])
 
 package_locks = List(Tuple(Unicode(), Unicode(), Unicode()))
 PACKAGE_LOCKS = Message(

--- a/landscape/package/facade.py
+++ b/landscape/package/facade.py
@@ -425,6 +425,10 @@ class AptFacade(object):
             return False
         return version > version.package.installed
 
+    def is_package_autoremovable(self, version):
+        """Was the package auto-installed, but isn't required anymore?"""
+        return version.package.is_auto_removable
+
     def _is_main_architecture(self, package):
         """Is the package for the facade's main architecture?"""
         # package.name includes the architecture, if it's for a foreign

--- a/landscape/package/facade.py
+++ b/landscape/package/facade.py
@@ -833,3 +833,9 @@ class AptFacade(object):
     def mark_remove_hold(self, version):
         """Mark the package to have its hold removed."""
         self._version_hold_removals.append(version)
+
+    def mark_auto_remove(self):
+        """Mark  for removal packages which are considered auto_removable."""
+        for version in self.get_packages():
+            if version.package.is_auto_removable:
+                self.mark_remove(version)

--- a/landscape/package/facade.py
+++ b/landscape/package/facade.py
@@ -839,7 +839,7 @@ class AptFacade(object):
         self._version_hold_removals.append(version)
 
     def mark_auto_remove(self):
-        """Mark  for removal packages which are considered auto_removable."""
+        """Mark for removal packages which are considered auto_removable."""
         for version in self.get_packages():
             if version.package.is_auto_removable:
                 self.mark_remove(version)

--- a/landscape/package/facade.py
+++ b/landscape/package/facade.py
@@ -837,9 +837,3 @@ class AptFacade(object):
     def mark_remove_hold(self, version):
         """Mark the package to have its hold removed."""
         self._version_hold_removals.append(version)
-
-    def mark_auto_remove(self):
-        """Mark for removal packages which are considered auto_removable."""
-        for version in self.get_packages():
-            if version.package.is_auto_removable:
-                self.mark_remove(version)

--- a/landscape/package/store.py
+++ b/landscape/package/store.py
@@ -214,6 +214,25 @@ class PackageStore(HashIdStore):
         return [row[0] for row in cursor.fetchall()]
 
     @with_cursor
+    def add_autoremovable(self, cursor, ids):
+        for id in ids:
+            cursor.execute("REPLACE INTO autoremovable VALUES (?)", (id,))
+
+    @with_cursor
+    def remove_autoremovable(self, cursor, ids):
+        id_list = ",".join(str(int(id)) for id in ids)
+        cursor.execute("DELETE FROM autoremovable WHERE id IN (%s)" % id_list)
+
+    @with_cursor
+    def clear_autoremovable(self, cursor):
+        cursor.execute("DELETE FROM autoremovable")
+
+    @with_cursor
+    def get_autoremovable(self, cursor):
+        cursor.execute("SELECT id FROM autoremovable")
+        return [row[0] for row in cursor.fetchall()]
+
+    @with_cursor
     def add_installed(self, cursor, ids):
         for id in ids:
             cursor.execute("REPLACE INTO installed VALUES (?)", (id,))
@@ -431,6 +450,8 @@ def ensure_package_schema(db):
     #       try block.
     cursor = db.cursor()
     try:
+        cursor.execute("CREATE TABLE autoremovable"
+                       " (id INTEGER PRIMARY KEY)")
         cursor.execute("CREATE TABLE locked"
                        " (id INTEGER PRIMARY KEY)")
         cursor.execute("CREATE TABLE available"

--- a/landscape/package/tests/test_facade.py
+++ b/landscape/package/tests/test_facade.py
@@ -2724,27 +2724,6 @@ class AptFacadeTest(LandscapeTest):
         self.assertEqual(
             apt_pkg.SELSTATE_DEINSTALL, foo.package._pkg.selected_state)
 
-    def test_mark_auto_remove(self):
-        """If a package is auto_removable, mark_auto_remove marks it."""
-        self._add_system_package("auto")
-        self._add_system_package("newauto")
-        self._add_system_package("foo", control_fields={"Depends": "newauto"})
-        self.facade.reload_channels()
-        auto, = sorted(self.facade.get_packages_by_name("auto"))
-        auto.package.mark_auto(True)
-        auto.package.mark_install(False)
-        newauto, = sorted(self.facade.get_packages_by_name("newauto"))
-        newauto.package.mark_auto(True)
-
-        self.facade.mark_auto_remove()
-
-        newauto, = sorted(self.facade.get_packages_by_name("newauto"))
-        self.assertTrue(auto.package.is_installed)
-        self.assertTrue(auto.package.is_auto_installed)
-        self.assertTrue(newauto.package.is_installed)
-        self.assertTrue(auto.package.is_auto_installed)
-        self.assertEqual([auto], self.facade._version_removals)
-
     def test_creation_of_key_ring(self):
         """
         Apt on Trusty requires a keyring exist in its directory structure, so

--- a/landscape/package/tests/test_facade.py
+++ b/landscape/package/tests/test_facade.py
@@ -891,7 +891,6 @@ class AptFacadeTest(LandscapeTest):
         self.assertTrue(self.facade.is_package_autoremovable(dep))
         self.assertFalse(self.facade.is_package_autoremovable(newdep))
 
-
     def test_is_package_available_in_channel_not_installed(self):
         """
         A package is considered available if the package is in a
@@ -2727,7 +2726,6 @@ class AptFacadeTest(LandscapeTest):
 
     def test_mark_auto_remove(self):
         """If a package is auto_removable, mark_auto_remove marks it."""
-        deb_dir = self.makeDir()
         self._add_system_package("auto")
         self._add_system_package("newauto")
         self._add_system_package("foo", control_fields={"Depends": "newauto"})

--- a/landscape/package/tests/test_facade.py
+++ b/landscape/package/tests/test_facade.py
@@ -867,6 +867,31 @@ class AptFacadeTest(LandscapeTest):
         self.assertEqual("version2-release2", version2.version)
         self.assertFalse(self.facade.is_package_installed(version2))
 
+    def test_is_package_autoremovable(self):
+        """
+        Check that auto packages without dependencies on them are correctly
+        detected as being autoremovable.
+        """
+        self._add_system_package("dep")
+        self._add_system_package("newdep")
+        self._add_system_package("foo", control_fields={"Depends": "newdep"})
+        self.facade.reload_channels()
+        dep, = sorted(self.facade.get_packages_by_name("dep"))
+        dep.package.mark_auto(True)
+        # dep should not be explicitely installed
+        dep.package.mark_install(False)
+        newdep, = sorted(self.facade.get_packages_by_name("newdep"))
+        newdep, = sorted(self.facade.get_packages_by_name("newdep"))
+        newdep.package.mark_auto(True)
+        self.assertTrue(dep.package.is_installed)
+        self.assertTrue(dep.package.is_auto_installed)
+        self.assertTrue(newdep.package.is_installed)
+        self.assertTrue(dep.package.is_auto_installed)
+
+        self.assertTrue(self.facade.is_package_autoremovable(dep))
+        self.assertFalse(self.facade.is_package_autoremovable(newdep))
+
+
     def test_is_package_available_in_channel_not_installed(self):
         """
         A package is considered available if the package is in a

--- a/landscape/package/tests/test_reporter.py
+++ b/landscape/package/tests/test_reporter.py
@@ -90,6 +90,8 @@ class PackageReporterAptTest(LandscapeTest):
         self.set_pkg1_installed()
         self.facade.reload_channels()
         name1 = sorted(self.facade.get_packages_by_name("name1"))[0]
+        # Since no other package depends on this, all that's needed
+        # to have it autoremovable is to mark it as installed+auto.
         name1.package.mark_auto(True)
 
     def _make_fake_apt_update(self, out="output", err="error", code=0):
@@ -955,6 +957,8 @@ class PackageReporterAptTest(LandscapeTest):
 
         self.store.set_hash_ids({HASH1: 1, HASH2: 2, HASH3: 3})
         self.store.add_available([1, 2, 3])
+        # We don't care about checking other state changes in this test.
+        # In reality the package would also be installed, available, etc.
         self.store.add_autoremovable([1, 2])
 
         result = self.successResultOf(self.reporter.detect_packages_changes())

--- a/landscape/package/tests/test_store.py
+++ b/landscape/package/tests/test_store.py
@@ -271,6 +271,23 @@ class PackageStoreTest(LandscapeTest):
         self.store1.clear_available_upgrades()
         self.assertEqual(self.store2.get_available_upgrades(), [])
 
+    def test_add_and_get_autoremovable(self):
+        self.store1.add_autoremovable([1, 2])
+        value = self.store1.get_autoremovable()
+        self.assertEqual([1, 2], value)
+
+    def test_clear_autoremovable(self):
+        self.store1.add_autoremovable([1, 2])
+        self.store1.clear_autoremovable()
+        value = self.store1.get_autoremovable()
+        self.assertEqual([], value)
+
+    def test_remove_autoremovable(self):
+        self.store1.add_autoremovable([1, 2, 3, 4])
+        self.store1.remove_autoremovable([2, 4, 5])
+        value = self.store1.get_autoremovable()
+        self.assertEqual([1, 3], value)
+
     def test_add_and_get_installed_packages(self):
         self.store1.add_installed([1, 2])
         self.assertEqual(self.store2.get_installed(), [1, 2])
@@ -335,6 +352,9 @@ class PackageStoreTest(LandscapeTest):
         database = sqlite3.connect(filename)
         cursor = database.cursor()
         cursor.execute("pragma table_info(locked)")
+        result = cursor.fetchall()
+        self.assertTrue(len(result) > 0)
+        cursor.execute("pragma table_info(autoremovable)")
         result = cursor.fetchall()
         self.assertTrue(len(result) > 0)
 


### PR DESCRIPTION
This changes adds client bits to report autoremovable packages back to landscape-server so it can act on them. lp:1208393

Testing: 

sudo apt-get install sl && sudo apt-mark auto sl && apt-get autoremove --dry-run
sudo ./scripts/landscape-client -c root-client.conf
accept in landscape, wait forever for package data to sync or not (server doesn't know about that field)
/tmp/landscape-root/package-reporter.log should queue autoremovable once (those are diffs)
grep autoremovable /tmp/landscape-root/broker.log # shows package report being sent even if currently ignored by servers