### PR TITLE
Sets vm_info to "kvm" for new AWS EC2 C5 instances which are now based on kvm.

### DIFF
--- a/landscape/lib/tests/test_vm_info.py
+++ b/landscape/lib/tests/test_vm_info.py
@@ -63,6 +63,14 @@ class GetVMInfoTest(BaseTestCase):
 
         self.assertEqual(b"", get_vm_info(root_path=self.root_path))
 
+    def test_get_vm_info_with_ec2_sys_vendor(self):
+        """
+        get_vm_info should return "kvm" when sys_vendor is "Amazon EC2",
+        which is the case for C5 instances which are based on KVM.
+        """
+        self.make_sys_vendor("Amazon EC2")
+        self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
+
     def test_get_vm_info_with_bochs_sys_vendor(self):
         """
         L{get_vm_info} should return "kvm" when we detect the sys_vendor is

--- a/landscape/lib/vm_info.py
+++ b/landscape/lib/vm_info.py
@@ -56,6 +56,7 @@ def _get_vm_by_vendor(sys_vendor_path):
     # Use lower-key string for vendors, since we do case-insentive match.
     # We need bytes here as required by the message schema.
     content_vendors_map = (
+        ("amazon ec2", b"kvm"),
         ("bochs", b"kvm"),
         ("google", b"gce"),
         ("innotek", b"virtualbox"),


### PR DESCRIPTION
Testing instructions:

register client.
verify the client is seen as kvm (and uses VM seat).