### PR TITLE
set vm_info to kvm for digitalocean instances

### DIFF
--- a/landscape/lib/tests/test_vm_info.py
+++ b/landscape/lib/tests/test_vm_info.py
@@ -71,6 +71,13 @@ class GetVMInfoTest(BaseTestCase):
         self.make_sys_vendor("Amazon EC2")
         self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
 
+    def test_get_vm_info_with_digitalocean_sys_vendor(self):
+        """
+        get_vm_info should return "kvm" when sys_vendor is "DigitalOcean".
+        """
+        self.make_sys_vendor("DigitalOcean")
+        self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
+
     def test_get_vm_info_with_bochs_sys_vendor(self):
         """
         L{get_vm_info} should return "kvm" when we detect the sys_vendor is

--- a/landscape/lib/vm_info.py
+++ b/landscape/lib/vm_info.py
@@ -55,9 +55,14 @@ def _get_vm_by_vendor(sys_vendor_path):
     vendor = read_text_file(sys_vendor_path).lower()
     # Use lower-key string for vendors, since we do case-insentive match.
     # We need bytes here as required by the message schema.
+
+    # 2018-01: AWS and DO are now returning custom sys_vendor names
+    # instead of qemu. If this becomes a trend, it may be worth also checking
+    # dmi/id/chassis_vendor which seems to unchanged (bochs).
     content_vendors_map = (
         ("amazon ec2", b"kvm"),
         ("bochs", b"kvm"),
+        ("digitalocean", b"kvm"),
         ("google", b"gce"),
         ("innotek", b"virtualbox"),
         ("microsoft", b"hyperv"),


### PR DESCRIPTION
Set vm-info to kvm for digitalocean droplets.