### PR TITLE
Source python.mk from the correct python versioned directory

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@ dist_release := $(shell lsb_release -cs)
 
 dh_extra_flags = -plandscape-common -plandscape-client
 
--include /usr/share/python/python.mk
+include /usr/share/python3/python.mk
 ifeq (,$(py_sitename))
 	py_sitename = site-packages
 	py_libdir = /usr/lib/python$(subst python,,$(1))/site-packages


### PR DESCRIPTION
Fixes  LP: #1737729

I'm a bit wary of "hardcoding" the python version like that, but it seems we are all in with python 3 with this package. I also removed the "-" prefix from the include directory because I want to know if the file isn't there.