### PR TITLE
Best-effort decode old py27 message keys.

### DIFF
--- a/landscape/client/broker/tests/test_store.py
+++ b/landscape/client/broker/tests/test_store.py
@@ -4,6 +4,7 @@ import mock
 
 from twisted.python.compat import intToBytes
 
+from landscape.lib.bpickle import dumps
 from landscape.lib.persist import Persist
 from landscape.lib.schema import InvalidError, Int, Bytes, Unicode
 from landscape.message_schemas.message import Message
@@ -623,3 +624,20 @@ class MessageStoreTest(LandscapeTest):
         self.store.record_failure((7 * 24 * 60 * 60) + 1)
         [empty, message] = self.store.get_pending_messages()
         self.assertEqual("resynchronize", message["type"])
+
+    def test_wb_get_pending_legacy_messages(self):
+        """Pending messages queued by legacy py27 are converted."""
+        filename = os.path.join(self.temp_dir, "0", "0")
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        with open(filename, "wb") as fh:
+            fh.write(dumps({b"type": b"data",
+                            b"data": b"A thing",
+                            b"api": b"3.2"}))
+        [message] = self.store.get_pending_messages()
+        # message keys are decoded
+        self.assertIn(u"type", message)
+        self.assertIn(u"api", message)
+        self.assertIsInstance(message[u"api"], bytes)  # api is bytes
+        self.assertEqual(u"data", message[u"type"])  # message type is decoded
+        self.assertEqual(b"A thing", message[u"data"])  # other are kept as-is
+

--- a/landscape/client/broker/tests/test_store.py
+++ b/landscape/client/broker/tests/test_store.py
@@ -640,4 +640,3 @@ class MessageStoreTest(LandscapeTest):
         self.assertIsInstance(message[u"api"], bytes)  # api is bytes
         self.assertEqual(u"data", message[u"type"])  # message type is decoded
         self.assertEqual(b"A thing", message[u"data"])  # other are kept as-is
-

--- a/landscape/client/broker/tests/test_store.py
+++ b/landscape/client/broker/tests/test_store.py
@@ -628,7 +628,7 @@ class MessageStoreTest(LandscapeTest):
     def test_wb_get_pending_legacy_messages(self):
         """Pending messages queued by legacy py27 are converted."""
         filename = os.path.join(self.temp_dir, "0", "0")
-        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        os.makedirs(os.path.dirname(filename))
         with open(filename, "wb") as fh:
             fh.write(dumps({b"type": b"data",
                             b"data": b"A thing",


### PR DESCRIPTION
Testing instructions:

* apt-install landscape-client. (py27)
* configure in /etc/landscape/client.conf
* call /usr/bin/landscape-client and wait to be messages pending delivery
  * check /var/lib/landscape/client/messages/0 for a couple messages
* run ./script/landscape-broker -c /etc/landscape/client.conf \
    -d /var/lib/landscape/client
* Messages get delivered, broker queue gets emptied, no stack trace on client.
* Check on message-server for delivered messages.