### PR TITLE
Decode server uuid pre-py3 upgrade. (LP: #1718696)

### DIFF
--- a/landscape/client/broker/store.py
+++ b/landscape/client/broker/store.py
@@ -201,7 +201,12 @@ class MessageStore(object):
 
     def get_server_uuid(self):
         """Return the currently set server UUID."""
-        return self._persist.get("server_uuid")
+        uuid = self._persist.get("server_uuid")
+        try:
+            return uuid.decode("ascii")
+        except AttributeError:
+            pass
+        return uuid
 
     def set_server_uuid(self, uuid):
         """Change the known UUID from the server we're communicating to."""

--- a/landscape/client/broker/tests/test_store.py
+++ b/landscape/client/broker/tests/test_store.py
@@ -62,6 +62,20 @@ class MessageStoreTest(LandscapeTest):
         store = self.create_store()
         self.assertEqual(store.get_server_uuid(), "abcd-efgh")
 
+    def test_get_set_server_uuid_py27(self):
+        """
+        Check get_server_uuid gets decoded value if it was stored
+        prior to py3 client upgrade.
+        """
+        self.assertEqual(self.store.get_server_uuid(), None)
+        self.store.set_server_uuid(b"abcd-efgh")
+        self.assertEqual(self.store.get_server_uuid(), "abcd-efgh")
+
+        # Ensure it's actually saved.
+        self.store.commit()
+        store = self.create_store()
+        self.assertEqual(store.get_server_uuid(), "abcd-efgh")
+
     def test_get_set_exchange_token(self):
         """
         The next-exchange-token value can be persisted and retrieved.

--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -355,12 +355,22 @@ class PackageReporter(PackageTaskHandler):
 
     def handle_task(self, task):
         message = task.data
-        if message["type"] == "package-ids":
+        message_type = message["type"]
+        try:
+            message_type = message_type.decode("ascii")
+        except AttributeError:
+            pass
+
+        if message_type == "package-ids":
             self._got_task = True
             return self._handle_package_ids(message)
-        if message["type"] == "resynchronize":
+        if message_type == "resynchronize":
             self._got_task = True
             return self._handle_resynchronize()
+
+        # Skip and continue.
+        logging.warning("Unknown task message type: {!r}".format(message_type))
+        return succeed(None)
 
     def _handle_package_ids(self, message):
         unknown_hashes = []

--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -132,6 +132,22 @@ class PackageReporterAptTest(LandscapeTest):
         # Nothing bad should happen.
         return self.reporter.handle_tasks()
 
+    def test_set_package_ids_py27(self):
+        """Check py27 upgraded messages are decoded."""
+        self.store.add_task("reporter",
+                            {"type": b"package-ids", "ids": [123, 456],
+                             "request-id": 123})
+        result = self.reporter.handle_tasks()
+        self.assertIsInstance(result, Deferred)
+
+    @mock.patch("logging.warning", return_value=None)
+    def test_handle_task_unknown(self, mock_warn):
+        """handle_task fails warns about unknown messages."""
+        self.store.add_task("reporter", {"type": "spam"})
+        result = self.reporter.handle_tasks()
+        self.assertIsInstance(result, Deferred)
+        mock_warn.assert_called_once_with("Unknown task message type: 'spam'")
+
     def test_set_package_ids_with_unknown_hashes(self):
         message_store = self.broker_service.message_store
 

--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -146,7 +146,8 @@ class PackageReporterAptTest(LandscapeTest):
         self.store.add_task("reporter", {"type": "spam"})
         result = self.reporter.handle_tasks()
         self.assertIsInstance(result, Deferred)
-        mock_warn.assert_called_once_with("Unknown task message type: 'spam'")
+        expected = "Unknown task message type: {!r}".format(u"spam")  # py2/3
+        mock_warn.assert_called_once_with(expected)
 
     def test_set_package_ids_with_unknown_hashes(self):
         message_store = self.broker_service.message_store


### PR DESCRIPTION

Testing instructions:

These exact steps reproduce the initial issue. Any other step has the risk
of server_uuid being seen as changed and properly persisted.
* apt install landscape client (py2.7)
* request registration. stop client.
* accept client
* sudo ./scripts/landscape-client -c /etc/landscape/client.conf
* tail -F /var/log/landscape/package-reporter.log | grep hash-id
Check for 404. If you're using racecar and have no hash-id-db, check
the URL being hit on landscape doesn't contain b"<server_uuid>"