### PR TITLE
decode message types in task handler and continue on unknown type

### DIFF
--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -356,10 +356,6 @@ class PackageReporter(PackageTaskHandler):
     def handle_task(self, task):
         message = task.data
         message_type = message["type"]
-        try:
-            message_type = message_type.decode("ascii")
-        except AttributeError:
-            pass
 
         if message_type == "package-ids":
             self._got_task = True


### PR DESCRIPTION
Testing:

* install landscape-client on artful/bionic
  * kick a package profile (should break because of apt-secure being default in distro, but the task will stay)
* upgrade
* verify package-changer/monitor logs for stack trace