### PR TITLE
Add decoding to registration and shutdown data.

### DIFF
--- a/landscape/client/broker/registration.py
+++ b/landscape/client/broker/registration.py
@@ -30,7 +30,11 @@ class RegistrationError(Exception):
 def persist_property(name):
 
     def get(self):
-        return self._persist.get(name)
+        value = self._persist.get(name)
+        try:
+            return value.decode("ascii")
+        except (AttributeError, UnicodeDecodeError):
+            return value
 
     def set(self, value):
         self._persist.set(name, value)

--- a/landscape/client/broker/tests/test_registration.py
+++ b/landscape/client/broker/tests/test_registration.py
@@ -45,6 +45,11 @@ class IdentityTest(LandscapeTest):
         self.check_persist_property("secure_id",
                                     "registration.secure-id")
 
+    def test_secure_id_as_unicode(self):
+        """secure-id is expected to be retrieved as unicode."""
+        self.identity.secure_id = b"spam"
+        self.assertEqual(self.identity.secure_id, "spam")
+
     def test_insecure_id(self):
         self.check_persist_property("insecure_id",
                                     "registration.insecure-id")

--- a/landscape/client/manager/shutdownmanager.py
+++ b/landscape/client/manager/shutdownmanager.py
@@ -113,7 +113,7 @@ class ShutdownProcessProtocol(ProcessProtocol):
 
     def get_data(self):
         """Get the data printed by the subprocess."""
-        return "".join(self._data)
+        return b"".join(self._data).decode("utf-8", "replace")
 
     def set_timeout(self, reactor, timeout=10):
         """

--- a/landscape/client/manager/tests/test_shutdownmanager.py
+++ b/landscape/client/manager/tests/test_shutdownmanager.py
@@ -48,8 +48,8 @@ class ShutdownManagerTest(LandscapeTest):
                   "result-text": u"Data may arrive in batches."}])
 
         protocol.result.addCallback(restart_performed)
-        protocol.childDataReceived(0, "Data may arrive ")
-        protocol.childDataReceived(0, "in batches.")
+        protocol.childDataReceived(0, b"Data may arrive ")
+        protocol.childDataReceived(0, b"in batches.")
         # We need to advance both reactors to simulate that fact they
         # are loosely in sync with each other
         self.broker_service.reactor.advance(10)
@@ -90,7 +90,7 @@ class ShutdownManagerTest(LandscapeTest):
         [arguments] = self.process_factory.spawns
         protocol = arguments[0]
         protocol.result.addCallback(restart_failed)
-        protocol.childDataReceived(0, "Failure text is reported.")
+        protocol.childDataReceived(0, b"Failure text is reported.")
         protocol.processEnded(Failure(ProcessTerminated(exitCode=1)))
         return protocol.result
 
@@ -125,11 +125,11 @@ class ShutdownManagerTest(LandscapeTest):
 
         [arguments] = self.process_factory.spawns
         protocol = arguments[0]
-        protocol.childDataReceived(0, "Data may arrive ")
-        protocol.childDataReceived(0, "in batches.")
+        protocol.childDataReceived(0, b"Data may arrive ")
+        protocol.childDataReceived(0, b"in batches.")
         self.manager.reactor.advance(10)
         self.assertEqual(protocol.get_data(), "Data may arrive in batches.")
-        protocol.childDataReceived(0, "Even when you least expect it.")
+        protocol.childDataReceived(0, b"Even when you least expect it.")
         self.assertEqual(protocol.get_data(), "Data may arrive in batches.")
 
     def test_restart_stops_exchanger(self):


### PR DESCRIPTION
* ShutdownManager was erroneously concatenating  bytes as str, unlike
  other ProcessProtocol subclasses which appear correct.
* Registration data is stored and fetched as bytes, whereas test code
  and callsites assume str, thus breaking exchange comparison of
  secure-id when the service restarts during the activity processing.

Testing instructions:

Although the behaviour is seen during an upgrade, it can easily be triggered
from py3 only.
* Register against landscape
* Request a reboot
* (restart the client after reboot)
* expect the activity to succeed.