### PR TITLE
Use lxd containers for CI testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,36 +3,45 @@ sudo: true
 language: python
 matrix:
   include:
-    - env: TARGET=check3 IMAGE=ubuntu:xenial
+    - env: TARGET=check2 IMAGE=ubuntu:xenial
       script:
-        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get update && sudo apt-get -y install make python3-distutils-extra python3-mock python3-twisted python3-apt python-twisted-core"';
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get update && sudo apt-get -y install make python-distutils-extra python-mock python-twisted python-apt python-twisted-core python-pycurl"';
         # creates user and dirs, some used through tests
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get -y install landscape-common"';
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo chown -R ubuntu:ubuntu /target"';
         - sg lxd -c 'lxc exec testcontainer -- sudo -i -u ubuntu sh -c "cd /target; make ${TARGET}" ubuntu';
-#    - env: TARGET=check3 IMAGE=ubuntu-daily:bionic
-#    - python: 3.6
-#      env: TARGET=lint
-#    - python: 3.4
-#      env: TARGET=coverage
-#      before_script:
-#        - python3 -m pip install -U coverage
-#        - python3 -m pip install -U codecov
-#      script:
-#        - make $TARGET
-#      after_success:
-#        - codecov
-# XXX cache the installs?
+    - env: TARGET=check3 IMAGE=ubuntu-daily:bionic
+      script:
+        # bionic needs cgroupv2 not on this kernel, so nudge the system a bit
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "dhclient eth0; cloud-init init"';
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get update && sudo apt-get -y install make python3-distutils-extra python3-mock python3-twisted python3-apt python-twisted-core python3-pycurl"';
+        # creates user and dirs, some used through tests
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get -y install landscape-common"';
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo chown -R ubuntu:ubuntu /target"';
+        - sg lxd -c 'lxc exec testcontainer -- sudo -i -u ubuntu sh -c "cd /target; make ${TARGET}" ubuntu';
+    - python: 3.6
+      env: TARGET=lint
+      install:
+        - pip install flake8
+    - python: 3.4
+      env: TARGET=coverage
+      before_script:
+        - python3 -m pip install -U coverage
+        - python3 -m pip install -U codecov
+      install:
+        - pip install flake8
+        # These match "make depends"
+        - pip install twisted==16.4.0 mock==1.3.0 configobj==5.0.6 pycurl
+        - pip install http://launchpad.net/python-distutils-extra/trunk/2.39/+download/python-distutils-extra-2.39.tar.gz
+        # build & install python-apt
+        - make -f Makefile.travis pipinstallpythonapt
+      script:
+        - make $TARGET
+      after_success:
+        - codecov
 env:
   global:
     - TRIAL_ARGS=-j4
-install:
-  # - pip install flake8
-  # # These match "make depends"
-  # - pip install twisted==16.4.0 mock==1.3.0 configobj==5.0.6 pycurl
-  # - pip install http://launchpad.net/python-distutils-extra/trunk/2.39/+download/python-distutils-extra-2.39.tar.gz
-  # # build & install python-apt
-  # - make -f Makefile.travis pipinstallpythonapt
 before_script:
   - if [ ! -z ${IMAGE} ]; then
       sudo apt-get -y -t trusty-backports install lxd;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,53 @@
 dist: trusty
 sudo: true
 language: python
-python:
-  - "3.4"
-  - "3.5"
-  - "3.6"
 matrix:
   include:
-    - python: 2.7
-      env: TARGET=check2
-    - python: 3.6
-      env: TARGET=lint
-    - python: 3.4
-      env:
-          TARGET=coverage
-      before_script:
-        - python3 -m pip install -U coverage
-        - python3 -m pip install -U codecov
+    - env: TARGET=check3 IMAGE=ubuntu:xenial
       script:
-        - make $TARGET
-      after_success:
-        - codecov
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get update && sudo apt-get -y install make python3-distutils-extra python3-mock python3-twisted python3-apt python-twisted-core"';
+        # creates user and dirs, some used through tests
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get -y install landscape-common"';
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo chown -R ubuntu:ubuntu /target"';
+        - sg lxd -c 'lxc exec testcontainer -- sudo -i -u ubuntu sh -c "cd /target; make ${TARGET}" ubuntu';
+#    - env: TARGET=check3 IMAGE=ubuntu-daily:bionic
+#    - python: 3.6
+#      env: TARGET=lint
+#    - python: 3.4
+#      env: TARGET=coverage
+#      before_script:
+#        - python3 -m pip install -U coverage
+#        - python3 -m pip install -U codecov
+#      script:
+#        - make $TARGET
+#      after_success:
+#        - codecov
 # XXX cache the installs?
 env:
   global:
     - TRIAL_ARGS=-j4
-  matrix:
-    - TARGET=check3
 install:
-  - pip install flake8
-  # These match "make depends"
-  - pip install twisted==16.4.0 mock==1.3.0 configobj==5.0.6 pycurl
-  - pip install http://launchpad.net/python-distutils-extra/trunk/2.39/+download/python-distutils-extra-2.39.tar.gz
-  # build & install python-apt
-  - make -f Makefile.travis pipinstallpythonapt
+  # - pip install flake8
+  # # These match "make depends"
+  # - pip install twisted==16.4.0 mock==1.3.0 configobj==5.0.6 pycurl
+  # - pip install http://launchpad.net/python-distutils-extra/trunk/2.39/+download/python-distutils-extra-2.39.tar.gz
+  # # build & install python-apt
+  # - make -f Makefile.travis pipinstallpythonapt
+before_script:
+  - if [ ! -z ${IMAGE} ]; then
+      sudo apt-get -y -t trusty-backports install lxd;
+      sudo lxd init --auto;
+      sudo usermod -a -G lxd travis;
+      sudo sed -e 's/LXD_IPV4_ADDR=""/LXD_IPV4_ADDR="10.0.8.1"/' -e 's/LXD_IPV4_NETMASK=""/LXD_IPV4_NETMASK="255.255.255.0"/' -e 's:LXD_IPV4_NETWORK="":LXD_IPV4_NETWORK="10.0.8.0/24":' -e 's/LXD_IPV4_DHCP_RANGE=""/LXD_IPV4_DHCP_RANGE="10.0.8.2,10.0.8.254"/' -e 's/LXD_IPV4_DHCP_MAX=""/LXD_IPV4_DHCP_MAX="250"/' -i /etc/default/lxd-bridge;
+      sudo /etc/init.d/lxd restart;
+   fi
+  - if [ ! -z ${IMAGE} ]; then
+      sg lxd -c 'lxc launch ${IMAGE} testcontainer -c security.privileged=true';
+      echo "waiting for nic";
+      for t in 1 2 5 8; do sg lxd -c 'lxc list' | grep 10.0.8 && break; sleep ${t}; done;
+      sg lxd -c 'lxc config device add testcontainer srcdir disk path=/target source=${PWD}';
+      sg lxd -c 'lxc config device add testcontainer srcdir disk path=/target source=${PWD}';
+      sg lxd -c 'lxc exec testcontainer -- sh -c "echo 1 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6"';
+    fi
 script:
-  - make $TARGET PYTHON=python$TRAVIS_PYTHON_VERSION
+  - make $TARGET PYTHON=python$TRAVIS_PYTHON_VERSION;

--- a/landscape/lib/tests/test_network.py
+++ b/landscape/lib/tests/test_network.py
@@ -31,7 +31,7 @@ class NetworkInfoTest(BaseTestCase):
             ["/sbin/ifconfig"], stdout=PIPE, env={"LC_ALL": "C"})
         result = process.communicate()[0].decode("ascii")
         interface_blocks = dict(
-            [(block.split()[0], block.upper()) for block in
+            [(block.split()[0].strip(":"), block.upper()) for block in
              filter(None, result.split("\n\n"))])
 
         for device in device_info:


### PR DESCRIPTION
This replaces the python test matrix by containerized runs on xenial (py2) and bionic (py3).
Apart from highlighting a small issue with tests (fixed in this branch), it seems containers run slightly
faster than pip dependencies (still used for coverage and lint).
Check the travis status for verification.