### PR TITLE
Revert the original change for #1621978

### DIFF
--- a/debian/landscape-common.postinst
+++ b/debian/landscape-common.postinst
@@ -81,9 +81,6 @@ case "$1" in
         #########################################
         # from landscape-sysinfo
 
-        # Since motd shows a different number of security updates, suppress the message
-        dpkg-divert --package $PACKAGE --rename /etc/update-motd.d/90-updates-available
-
         db_get $PACKAGE/sysinfo
         # Choices:
         #  * Do not display sysinfo on login

--- a/debian/landscape-common.prerm
+++ b/debian/landscape-common.prerm
@@ -20,7 +20,6 @@ PACKAGE=landscape-common
 
 case "$1" in
     remove|upgrade|deconfigure)
-       dpkg-divert --remove --package $PACKAGE --rename /etc/update-motd.d/90-updates-available
        rm -f /etc/update-motd.d/50-landscape-sysinfo 2>/dev/null || true
        update-motd 2>/dev/null || true
        rm -f /etc/profile.d/landscape-sysinfo.sh 2>/dev/null || true


### PR DESCRIPTION
Revert the original change for #1621978. The dpkg-divert was in the wrong package (common instead of client), but even so, the mere presence of the client package doesn't mean this system is managed by landscape: the registration should be checked.
