### PR TITLE
Remove unused variable

### DIFF
--- a/debian/landscape-common.prerm
+++ b/debian/landscape-common.prerm
@@ -16,7 +16,6 @@ set -e
 # for details, see http://www.debian.org/doc/debian-policy/ or
 # the debian-policy package
 
-PACKAGE=landscape-common
 
 case "$1" in
     remove|upgrade|deconfigure)


### PR DESCRIPTION
It's a leftover from when the dpkg-divert change was reverted in a previous commit.