### PR TITLE
Extend vm_info detection to other dmi fields.

### DIFF
--- a/landscape/lib/tests/test_vm_info.py
+++ b/landscape/lib/tests/test_vm_info.py
@@ -79,11 +79,19 @@ class GetVMInfoTest(BaseTestCase):
         self.make_dmi_info("sys_vendor", "DigitalOcean")
         self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
 
+    def test_get_vm_info_with_kvm_bios_vendor(self):
+        """
+        get_vm_info should return "kvm" when bios_vendor maps to kvm.
+        """
+        # DigitalOcean is known to set the bios_vendor on their instances.
+        self.make_dmi_info("bios_vendor", "DigitalOcean")
+        self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
+
     def test_get_vm_info_with_bochs_chassis_vendor(self):
         """
         get_vm_info should return "kvm" when chassis_vendor is "Bochs".
         """
-        # DigitalOcean, AWs and Cloudstack are known to customize sys_vendor
+        # DigitalOcean, AWS and Cloudstack are known to customize sys_vendor
         # and/or bios_vendor.
         self.make_dmi_info("sys_vendor", "Apache Software Foundation")
         self.make_dmi_info("chassis_vendor", "Bochs")


### PR DESCRIPTION
Scan sys, bios and chassis DMI to detect hypervisor (LP: #1754073)

Testing instructions:

```
uvt-simplestreams-libvirt --verbose sync arch~amd64 release~xenial
uvt-kvm create vm
virsh edit vm
<os>
...
<smbios mode='sysinfo'/>
</os>
<sysinfo type="smbios">
  <system>
    <entry name='manufacturer'>Apache Software Foundation</entry>
    <entry name='product'>CloudStack KVM Hypervisor</entry>
  </system>
</sysinfo>
<cpu match='exact'> <!-- defaults to qemu, which would me detected correctly -->
  <model fallback='allow'>core2duo</model>
  <vendor>Intel</vendor>
</cpu>

# save
virsh destroy vm && virsh start vm
uvt-kvm ssh vm --insecure

git clone --single-branch --branch 1754073_extend_kvm_detection https://github.com/simpoir/landscape-client && cd landscape-client
sudo apt-get build-dep ./ && sudo dpkg-buildpackage -b -us -uc
sudo dpkg -i ../landscape-*.deb
sudo apt-get -f install  # pull deps
sudo landscape-config --computer-title "My Web Server" --account-name devel --registration-key ...
# accept computer, notice "VM Type" is kvm in UI
```