### PR TITLE
Override the apt progress pulse().

### DIFF
--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -57,6 +57,15 @@ class LandscapeAcquireProgress(AcquireProgress):
         fcntl.ioctl API differences for different Python versions.
         """
 
+    def pulse(self, owner):
+        """Override updating the acquire progress, which needs a tty.
+
+        Under Python3, StringIO.fileno() raises UnsupportedOperation instead
+        of an AttributeError. This would be uncaught by apt, thus we force a
+        NOOP here.
+        """
+        return True
+
 
 class LandscapeInstallProgress(InstallProgress):
 


### PR DESCRIPTION
This should remove the tracebacks under python3 + bionic. (LP: #1758529)

Testing instructions:

```
edit root-client.conf
sudo ./scripts/landscape-client -r root-client.conf
log to landscape, accept the client, wait for packages to sync.
search for a package (e.g. fortune), mark it for install; wait.
grep pulse /tmp/landscape-root/*.log  # should return nothing
```