### PR TITLE
Return non-blank message when tasks already performed

### DIFF
--- a/landscape/client/package/changer.py
+++ b/landscape/client/package/changer.py
@@ -259,6 +259,8 @@ class PackageChanger(PackageTaskHandler):
             else:
                 result.code = SUCCESS_RESULT
 
+        if result.code == SUCCESS_RESULT and result.text is None:
+            result.text = 'No changes required; all changes already performed'
         return result
 
     def may_complement_changes(self, result, policy):

--- a/landscape/client/package/tests/test_changer.py
+++ b/landscape/client/package/tests/test_changer.py
@@ -641,6 +641,9 @@ class AptPackageChangerTest(LandscapeTest):
             self.assertMessages(self.get_pending_messages(),
                                 [{"operation-id": 123,
                                   "result-code": 1,
+                                  "result-text":
+                                      u"No changes required; all changes "
+                                      u"already performed",
                                   "type": "change-packages-result"}])
 
         return result.addCallback(got_result)


### PR DESCRIPTION
In the case that all tasks have already been performed (e.g. by external processes), return a meaningful message rather than nothing. (LP: #928933)