### PR TITLE
Add simfs to the whitelist of "stable" file-systems

### DIFF
--- a/landscape/lib/disk.py
+++ b/landscape/lib/disk.py
@@ -10,7 +10,7 @@ from twisted.python.compat import _PY3
 # List of filesystem types authorized when generating disk use statistics.
 STABLE_FILESYSTEMS = frozenset(
     ["ext", "ext2", "ext3", "ext4", "reiserfs", "ntfs", "msdos", "dos", "vfat",
-     "xfs", "hpfs", "jfs", "ufs", "hfs", "hfsplus"])
+     "xfs", "hpfs", "jfs", "ufs", "hfs", "hfsplus", "simfs"])
 
 
 EXTRACT_DEVICE = re.compile("([a-z]+)[0-9]*")
@@ -67,8 +67,6 @@ def get_filesystem_for_path(path, mounts_file, statvfs_):
     @param mounts_file: A file with information about mounted filesystems,
         such as C{/proc/mounts}.
     @param statvfs_: A function to get file status information.
-    @param filesystems_whitelist: Optionally, a list of which filesystems to
-        stat.
     @return: A C{dict} with C{device}, C{mount-point}, C{filesystem},
         C{total-space} and C{free-space} keys. If the filesystem information
         is not available, C{None} is returned. Both C{total-space} and

--- a/landscape/lib/tests/test_disk.py
+++ b/landscape/lib/tests/test_disk.py
@@ -31,7 +31,7 @@ class DiskUtilitiesTest(BaseTestCase):
         else:
             raise OSError("Permission denied")
 
-    def set_mount_points(self, points, read_access=True):
+    def set_mount_points(self, points, read_access=True, fs='ext4'):
         """
         This method prepares a fake mounts file containing the
         mount points specified in the C{points} list of strings. This file
@@ -41,7 +41,7 @@ class DiskUtilitiesTest(BaseTestCase):
         yield a permission denied error when inspected.
         """
         self.read_access = read_access
-        content = "\n".join("/dev/sda%d %s ext4 rw 0 0" % (i, point)
+        content = "\n".join("/dev/sda%d %s %s rw 0 0" % (i, point, fs)
                             for i, point in enumerate(points))
         f = open(self.mount_file, "w")
         f.write(content)
@@ -69,6 +69,11 @@ class DiskUtilitiesTest(BaseTestCase):
 
     def test_get_filesystem_subpath_not_stupid(self):
         self.set_mount_points(["/", "/ho"])
+        info = get_filesystem_for_path("/home", self.mount_file, self.statvfs)
+        self.assertEqual(info["mount-point"], "/")
+
+    def test_get_filesystem_weird_fs(self):
+        self.set_mount_points(["/"], fs='simfs')
         info = get_filesystem_for_path("/home", self.mount_file, self.statvfs)
         self.assertEqual(info["mount-point"], "/")
 


### PR DESCRIPTION
"simfs" is the file-system that OpenVZ instances appear to use for their storage. Without simfs in the stable file-systems white-list, clients are unable to see disk usage via the landscape client. (LP: #1499104)