### PR TITLE
Handle unicode apt-sources-replace (LP: #1771443)

### DIFF
--- a/landscape/client/manager/aptsources.py
+++ b/landscape/client/manager/aptsources.py
@@ -128,7 +128,10 @@ class AptSources(ManagerPlugin):
         for source in sources:
             filename = os.path.join(self.SOURCES_LIST_D,
                                     "landscape-%s.list" % source["name"])
-            with open(filename, "wb") as sources_file:
+            # Servers send unicode, but an upgrade from python2 can get bytes
+            # from stored messages, so we need to handle both.
+            is_unicode = isinstance(source["content"], type(u""))
+            with open(filename, ("w" if is_unicode else "wb")) as sources_file:
                 sources_file.write(source["content"])
             os.chmod(filename, 0o644)
         return self._run_reporter().addCallback(lambda ignored: None)

--- a/landscape/client/manager/tests/test_aptsources.py
+++ b/landscape/client/manager/tests/test_aptsources.py
@@ -105,6 +105,23 @@ class AptSourcesTests(LandscapeTest):
         with open(saved_sources_path) as saved_sources:
             self.assertEqual("original content\n", saved_sources.read())
 
+    def test_sources_list_unicode(self):
+        """
+        When receiving apt-sources-replace, client correctly also handles
+        unicode content correctly.
+        """
+        self.manager.dispatch_message(
+            {"type": "apt-sources-replace",
+             "sources": [{"name": "bla", "content": u"fancy content"}],
+             "gpg-keys": [],
+             "operation-id": 1})
+
+        saved_sources_path = os.path.join(
+            self.sourceslist.SOURCES_LIST_D, "landscape-bla.list")
+        self.assertTrue(os.path.exists(saved_sources_path))
+        with open(saved_sources_path, "rb") as saved_sources:
+            self.assertEqual(b"fancy content", saved_sources.read())
+
     def test_restore_sources_list(self):
         """
         When getting a repository message without sources, AptSources


### PR DESCRIPTION
Support both unicode and bytes content for apt-sources-replace,
as content should be unicode, but can be passed as bytes after a client
upgrade from python 2.7

Testing instructions:

* on a bionic container, ./scripts/landscape-client -c root-client.conf
* on the server,
  ```
make freshdata && ./dev/racecar
  source ./dev/setup_api
  curl 'https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0xC0B21F32' > mirror_key
  landscape-api import-gpg-key ubuntu-new-mirror-key ./mirror_key
  // the sign-key comes from freshdata
  landscape-api create-series --pockets security --components restricted --architectures amd64 --mirror-gpg-key ubuntu-new-mirror-key --gpg-key sign-key --mirror-uri http://archive.ubuntu.com/ubuntu/ --mirror-series bionic bionic-repo ubuntu
  landscape-api sync-mirror-pocket security bionic-repo ubuntu

  // create a profile
  landscape-api create-repository-profile --description "This profile is for Bionic-security-restricted" bio-secu-restricted-profile
  landscape-api associate-repository-profile --tags bionic-test bio-secu-restricted-profile

  // accept the bionic container, set the 'bionic-test' tag
  // the profile should apply, wait for it to succeed
  landscape-api add-pockets-to-repository-profile bio-secu-restricted-profile security bionic-repo ubuntu
  // the profile should apply again, wait for it to succeed again

```