### PR TITLE
Avoid leaking memory through unused twisted logs.

### DIFF
--- a/landscape/client/deployment.py
+++ b/landscape/client/deployment.py
@@ -2,6 +2,7 @@ import os.path
 import sys
 
 from optparse import SUPPRESS_HELP
+from twisted.logger import globalLogBeginner
 
 from landscape import VERSION
 from landscape.lib import logging
@@ -16,6 +17,10 @@ def init_logging(configuration, program_name):
     logging.init_app_logging(configuration.log_dir, configuration.log_level,
                              progname=program_name,
                              quiet=configuration.quiet)
+    # Initialize twisted logging, even if we don't explicitly use it,
+    # because of leaky logs https://twistedmatrix.com/trac/ticket/8164
+    globalLogBeginner.beginLoggingTo(
+        [lambda _: None], redirectStandardIO=False, discardBuffer=True)
 
 
 def _is_script(filename=sys.argv[0],


### PR DESCRIPTION
Twisted default log initialization is to use a 64k lines deque buffer,
each referencing the log_source objects, thus keeping a large amount of
references to twisted objects and keeping them from being collected.

This initializes the twisted logging to drop that buffer. (LP: #1685885)


Testing instructions:

The leak is not quite noticeable without waiting considerably.
The easiest way is to instrument a few process like the watchdog
(which is a good candidate because it does almost nothing)

in landscape/client/watchdog.py:418 add
+        import objgraph; print(objgraph.show_growth())

and call ./scripts/lanscape-client -c root-client.conf

And watch it level after a few seconds.
Other processes are harder to track as they go up and down considerably.
