### PR TITLE
Set LANG in sysinfo wrapper.

### DIFF
--- a/debian/landscape-sysinfo.wrapper
+++ b/debian/landscape-sysinfo.wrapper
@@ -1,4 +1,7 @@
 #!/bin/sh
+# pam_motd does not carry the environment
+[ -f /etc/default/locale ] && . /etc/default/locale
+export LANG
 cores=$(grep -c ^processor /proc/cpuinfo 2>/dev/null)
 [ "$cores" -eq "0" ] && cores=1
 threshold="${cores:-1}.0"

--- a/landscape/client/deployment.py
+++ b/landscape/client/deployment.py
@@ -2,6 +2,7 @@ import os.path
 import sys
 
 from optparse import SUPPRESS_HELP
+from twisted.logger import globalLogBeginner
 
 from landscape import VERSION
 from landscape.lib import logging
@@ -16,6 +17,10 @@ def init_logging(configuration, program_name):
     logging.init_app_logging(configuration.log_dir, configuration.log_level,
                              progname=program_name,
                              quiet=configuration.quiet)
+    # Initialize twisted logging, even if we don't explicitly use it,
+    # because of leaky logs https://twistedmatrix.com/trac/ticket/8164
+    globalLogBeginner.beginLoggingTo(
+        [lambda _: None], redirectStandardIO=False, discardBuffer=True)
 
 
 def _is_script(filename=sys.argv[0],


### PR DESCRIPTION
Avoid encoding errors scanning process (LP: #1780071)

Testing instructions:

on bionic or later
$ dpkg-buildpackage -b
$ dpkg -i ../landscape-common_18.03-0ubuntu1_amd64.deb
$ sh -c 'sleep 300; echo "ಠ_ಠ"' &
$ sudo login
Should show sysinfo as part of motd without printing the error log message.