### PR TITLE
Permit environments containing unicode chars for script execution

### DIFF
--- a/landscape/client/manager/scriptexecution.py
+++ b/landscape/client/manager/scriptexecution.py
@@ -259,9 +259,10 @@ class ScriptExecutionPlugin(ManagerPlugin, ScriptRunnerMixin):
             "PATH": UBUNTU_PATH,
             "USER": user or "",
             "HOME": path or "",
-            "LANG": os.environ.get("LANG", ""),
-            "LC_CTYPE": os.environ.get("LC_CTYPE", ""),
         }
+        for locale_var in ("LANG", "LC_ALL", "LC_CTYPE"):
+            if locale_var in os.environ:
+                env[locale_var] = os.environ[locale_var]
         if server_supplied_env:
             env.update(server_supplied_env)
         old_umask = os.umask(0o022)

--- a/landscape/client/manager/tests/test_scriptexecution.py
+++ b/landscape/client/manager/tests/test_scriptexecution.py
@@ -30,6 +30,7 @@ def get_default_environment():
         "USER": username,
         "HOME": home,
         "LANG": os.environ.get("LANG", ""),
+        "LC_ALL": os.environ.get("LC_ALL", ""),
         "LC_CTYPE": os.environ.get("LC_CTYPE", ""),
     }
 


### PR DESCRIPTION
The server supplied environment for a client-executed script may include unicode strings (e.g. when a computer's tag includes diacriticals). Currently, twisted throws an exception when encountering these as the default encoding it uses (on Python 2) is 'ascii'. This patch ensures all unicode strings in the environment are encoded appropriately prior to being passed to twisted for execution. The encoding used is from `sys.getfilesystemencoding()` as this is what Python 3 uses for its `os.environ` dict.

Furthermore, it ensures that various locale-relevant vars (LC_ALL, LC_CTYPE, LANG) aren't stripped from the environment, permitting the executed script to know what encoding to expect when querying the environment.