### PR TITLE
check chassis_vendor first for vm_info to allow for customized sys_vendor

### DIFF
--- a/landscape/lib/tests/test_vm_info.py
+++ b/landscape/lib/tests/test_vm_info.py
@@ -79,6 +79,13 @@ class GetVMInfoTest(BaseTestCase):
         self.make_dmi_info("sys_vendor", "DigitalOcean")
         self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
 
+    def test_get_vm_info_with_hetzner_sys_vendor(self):
+        """
+        get_vm_info should return "kvm" when sys_vendor is "Hetzner".
+        """
+        self.make_dmi_info("sys_vendor", "Hetzner")
+        self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
+
     def test_get_vm_info_with_kvm_bios_vendor(self):
         """
         get_vm_info should return "kvm" when bios_vendor maps to kvm.

--- a/landscape/lib/tests/test_vm_info.py
+++ b/landscape/lib/tests/test_vm_info.py
@@ -79,13 +79,6 @@ class GetVMInfoTest(BaseTestCase):
         self.make_dmi_info("sys_vendor", "DigitalOcean")
         self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
 
-    def test_get_vm_info_with_hetzner_sys_vendor(self):
-        """
-        get_vm_info should return "kvm" when sys_vendor is "Hetzner".
-        """
-        self.make_dmi_info("sys_vendor", "Hetzner")
-        self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
-
     def test_get_vm_info_with_kvm_bios_vendor(self):
         """
         get_vm_info should return "kvm" when bios_vendor maps to kvm.
@@ -102,6 +95,16 @@ class GetVMInfoTest(BaseTestCase):
         # and/or bios_vendor.
         self.make_dmi_info("sys_vendor", "Apache Software Foundation")
         self.make_dmi_info("chassis_vendor", "Bochs")
+        self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
+
+    def test_get_vm_info_with_qemu_chassis_vendor(self):
+        """
+        get_vm_info should return "kvm" when chassis_vendor is "QEMU".
+        """
+        # DigitalOcean, AWS and Cloudstack are known to customize sys_vendor
+        # and/or bios_vendor.
+        self.make_dmi_info("sys_vendor", "Apache Software Foundation")
+        self.make_dmi_info("chassis_vendor", "QEMU")
         self.assertEqual(b"kvm", get_vm_info(root_path=self.root_path))
 
     def test_get_vm_info_with_bochs_sys_vendor(self):

--- a/landscape/lib/vm_info.py
+++ b/landscape/lib/vm_info.py
@@ -22,7 +22,7 @@ def get_vm_info(root_path="/"):
     # Iterate through all dmi *_vendors, as clouds can (and will) customize
     # sysinfo values. (https://libvirt.org/formatdomain.html#elementsSysinfo)
     dmi_info_path = os.path.join(root_path, "sys/class/dmi/id")
-    for dmi_info_file in ("sys_vendor", "chassis_vendor", "bios_vendor"):
+    for dmi_info_file in ("chassis_vendor", "sys_vendor", "bios_vendor"):
         dmi_vendor_path = os.path.join(dmi_info_path, dmi_info_file)
         if not os.path.exists(dmi_vendor_path):
             continue
@@ -71,7 +71,6 @@ def _get_vm_by_vendor(sys_vendor_path):
         ("bochs", b"kvm"),
         ("digitalocean", b"kvm"),
         ("google", b"gce"),
-        ("hetzner", b"kvm"),
         ("innotek", b"virtualbox"),
         ("microsoft", b"hyperv"),
         ("openstack", b"kvm"),

--- a/landscape/lib/vm_info.py
+++ b/landscape/lib/vm_info.py
@@ -71,6 +71,7 @@ def _get_vm_by_vendor(sys_vendor_path):
         ("bochs", b"kvm"),
         ("digitalocean", b"kvm"),
         ("google", b"gce"),
+        ("hetzner", b"kvm"),
         ("innotek", b"virtualbox"),
         ("microsoft", b"hyperv"),
         ("openstack", b"kvm"),


### PR DESCRIPTION
Hetzner Cloud uses dmi sys_vendor to identify itself (e.g. to cloud-init).
This confuses landscape, so it needs to be treated like KVM
