### PR TITLE
Enable landscape-client to survive trusty upgrade

### DIFF
--- a/landscape/client/package/releaseupgrader.py
+++ b/landscape/client/package/releaseupgrader.py
@@ -210,6 +210,9 @@ class ReleaseUpgrader(PackageTaskHandler):
         @param allow_third_party: Whether to enable non-official APT repo.
         @param debug: Whether to turn on debug level logging.
         """
+        # This bizarre (and apparently unused) import is a workaround for
+        # LP: #1670291 -- see comments in that ticket for an explanation
+        import twisted.internet.unix  # noqa: F401
         upgrade_tool_directory = self._config.upgrade_tool_directory
         upgrade_tool_filename = os.path.join(upgrade_tool_directory, code_name)
         args = ["--frontend", "DistUpgradeViewNonInteractive"]


### PR DESCRIPTION
At present, landscape-client fails to report the completion (or failure) of a release upgrade from trusty to xenial due to the delayed import of twisted.internet.unix (part of LP: #1670291).

Testing instructions:

* Create a trusty container
* Patch the landscape client in the container
* Register it with landscape (either hosted or a test instance should do)
* Request a release upgrade (implicitly to xenial) of the client from landscape
* Ensure the result of the release upgrade is reported (success or failure) in landscape