### PR TITLE
Clear hash id database on package resync.

### DIFF
--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -400,15 +400,16 @@ class PackageReporter(PackageTaskHandler):
 
         return result
 
+    @inlineCallbacks
     def _handle_resynchronize(self):
+        self._store.clear_hash_ids()
+        yield self._remove_hash_id_db()
         self._store.clear_available()
         self._store.clear_available_upgrades()
         self._store.clear_installed()
         self._store.clear_locked()
         self._store.clear_hash_id_requests()
         self._store.clear_autoremovable()
-
-        return succeed(None)
 
     def _handle_unknown_packages(self, hashes):
 
@@ -443,6 +444,18 @@ class PackageReporter(PackageTaskHandler):
         else:
             result = succeed(None)
 
+        return result
+
+    def _remove_hash_id_db(self):
+
+        def _remove_it(hash_id_db_filename):
+            if hash_id_db_filename and os.path.exists(hash_id_db_filename):
+                logging.warning(
+                    "Removing cached hash=>id database %s",
+                    hash_id_db_filename)
+                os.remove(hash_id_db_filename)
+        result = self._determine_hash_id_db_filename()
+        result.addCallback(_remove_it)
         return result
 
     def remove_expired_hash_id_requests(self):

--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -1228,9 +1228,8 @@ class PackageReporterAptTest(LandscapeTest):
         hash_id_file = os.path.join(
             self.config.hash_id_directory, "uuid_codename_arch")
         os.makedirs(self.config.hash_id_directory)
-        with open(hash_id_file, "w") as f:
+        with open(hash_id_file, "w"):
             pass
-        self.assertFileContent(hash_id_file, b"")
 
         self.store.set_hash_ids({foo_hash: 3, HASH2: 4})
         self.store.add_available([1])
@@ -1269,8 +1268,6 @@ class PackageReporterAptTest(LandscapeTest):
         self.assertNotEqual(hash1, 3)
         self.assertNotEqual(hash2, 4)
         self.assertFalse(os.path.exists(hash_id_file))
-
-        # But the other data should.
         self.assertEqual(self.store.get_available_upgrades(), [])
 
         # After running the resychronize task, the hash db is empty,


### PR DESCRIPTION
This should avoid loop when inconsistencies are present in the database
through either corruption or server-restore. (LP: #1616116)

Testing instructions:

* launch a landscape server and register (using ppa packages is somewhat simpler as hash-db is pre-populated).
* register client against server. wait for package info
* pg_dumpall
* add a repo and wait for new package to show on client.
* restore postgres backup.
* trigger a package install from the new repo to have new package show up
* if you haven't regenerated hash-ids on the server, clients will be stuck in a loop. this is to be expected as the server is inconsistent with itself.
* client should resync once then will re-fetch hash on the next run. Some hash-id requests may go through in the meantime.