### PR TITLE
report packages from security-pocket

### DIFF
--- a/Makefile.travis
+++ b/Makefile.travis
@@ -11,6 +11,7 @@ pipinstallpythonapt: pipinstallpythonapt_deps
 pipinstallpythonapt_deps:
 	pip install pyopenssl
 	pip install service_identity
+	sudo apt-get update
 	sudo apt-get -y build-dep python-apt python3-apt
 	sudo apt-get -y install libapt-pkg-dev
 

--- a/landscape/lib/apt/package/store.py
+++ b/landscape/lib/apt/package/store.py
@@ -233,6 +233,25 @@ class PackageStore(HashIdStore):
         return [row[0] for row in cursor.fetchall()]
 
     @with_cursor
+    def add_security(self, cursor, ids):
+        for id in ids:
+            cursor.execute("REPLACE INTO security VALUES (?)", (id,))
+
+    @with_cursor
+    def remove_security(self, cursor, ids):
+        id_list = ",".join(str(int(id)) for id in ids)
+        cursor.execute("DELETE FROM security WHERE id IN (%s)" % id_list)
+
+    @with_cursor
+    def clear_security(self, cursor):
+        cursor.execute("DELETE FROM security")
+
+    @with_cursor
+    def get_security(self, cursor):
+        cursor.execute("SELECT id FROM security")
+        return [row[0] for row in cursor.fetchall()]
+
+    @with_cursor
     def add_installed(self, cursor, ids):
         for id in ids:
             cursor.execute("REPLACE INTO installed VALUES (?)", (id,))
@@ -450,6 +469,8 @@ def ensure_package_schema(db):
     #       try block.
     cursor = db.cursor()
     try:
+        cursor.execute("CREATE TABLE security"
+                       " (id INTEGER PRIMARY KEY)")
         cursor.execute("CREATE TABLE autoremovable"
                        " (id INTEGER PRIMARY KEY)")
         cursor.execute("CREATE TABLE locked"

--- a/landscape/message_schemas/server_bound.py
+++ b/landscape/message_schemas/server_bound.py
@@ -367,13 +367,16 @@ PACKAGES = Message(
      "locked": package_ids_or_ranges,
      "autoremovable": package_ids_or_ranges,
      "not-autoremovable": package_ids_or_ranges,
+     "security": package_ids_or_ranges,
      "not-installed": package_ids_or_ranges,
      "not-available": package_ids_or_ranges,
      "not-available-upgrades": package_ids_or_ranges,
-     "not-locked": package_ids_or_ranges},
+     "not-locked": package_ids_or_ranges,
+     "not-security": package_ids_or_ranges},
     optional=["installed", "available", "available-upgrades", "locked",
               "not-available", "not-installed", "not-available-upgrades",
-              "not-locked", "autoremovable", "not-autoremovable"])
+              "not-locked", "autoremovable", "not-autoremovable", "security",
+              "not-security"])
 
 package_locks = List(Tuple(Unicode(), Unicode(), Unicode()))
 PACKAGE_LOCKS = Message(


### PR DESCRIPTION

Testing instructions:

sudo ./scripts/landscape-client -c path_to_your_favorite_config

Check the debug logs for packages ids being reported. in addition to available,
there should be a couple of security.