### PR TITLE
Allow bad chars in system vendor files (LP: #1799843)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ ci-check: depends build check  ## Install dependencies and run all the tests.
 
 .PHONY: lint
 lint:
-	$(PYTHON3) -m flake8 --ignore E24,E121,E123,E125,E126,E221,E226,E266,E704,E265 \
+	$(PYTHON3) -m flake8 --ignore E24,E121,E123,E125,E126,E221,E226,E266,E704,E265,W504 \
 		`find landscape -name \*.py`
 
 .PHONY: pyflakes

--- a/landscape/client/broker/tests/test_store.py
+++ b/landscape/client/broker/tests/test_store.py
@@ -300,16 +300,16 @@ class MessageStoreTest(LandscapeTest):
         self.store.add({"type": "data", "data": 1})
         # We simulate it by creating a fake file which raises halfway through
         # writing a file.
-        with mock.patch("landscape.lib.fs.open") as mock_open:
-            mocked_file = mock_open.return_value
-            mocked_file.write.side_effect = IOError("Sorry, pal!")
+        mock_open = mock.mock_open()
+        with mock.patch("landscape.lib.fs.open", mock_open):
+            mock_open().write.side_effect = IOError("Sorry, pal!")
             # This kind of ensures that raising an exception is somewhat
             # similar to unplugging the power -- i.e., we're not relying
             # on special exception-handling in the file-writing code.
             self.assertRaises(
                 IOError, self.store.add, {"type": "data", "data": 2})
             mock_open.assert_called_with(mock.ANY, "wb")
-            mocked_file.write.assert_called_once_with(mock.ANY)
+            mock_open().write.assert_called_once_with(mock.ANY)
         self.assertEqual(self.store.get_pending_messages(),
                          [{"type": "data", "data": 1, "api": b"3.2"}])
 

--- a/landscape/client/monitor/processorinfo.py
+++ b/landscape/client/monitor/processorinfo.py
@@ -166,7 +166,7 @@ class ARMMessageFactory:
         file = open(self._source_filename)
 
         try:
-            regexp = re.compile("(?P<key>.*?)\s*:\s*(?P<value>.*)")
+            regexp = re.compile(r"(?P<key>.*?)\s*:\s*(?P<value>.*)")
             current = {}
 
             for line in file:
@@ -207,7 +207,7 @@ class SparcMessageFactory:
         file = open(self._source_filename)
 
         try:
-            regexp = re.compile("CPU(\d{1})+")
+            regexp = re.compile(r"CPU(\d{1})+")
 
             for line in file:
                 parts = line.split(":", 1)
@@ -216,7 +216,7 @@ class SparcMessageFactory:
                 if key == "cpu":
                     model = parts[1].strip()
                 elif regexp.match(key):
-                    start, end = re.compile("\d+").search(key).span()
+                    start, end = re.compile(r"\d+").search(key).span()
                     message = {"processor-id": int(key[start:end]),
                                "model": model}
                     processors.append(message)

--- a/landscape/client/monitor/tests/test_computerinfo.py
+++ b/landscape/client/monitor/tests/test_computerinfo.py
@@ -95,7 +95,7 @@ VmallocChunk:   107432 kB
         self.assertEqual(len(messages), 1)
         self.assertEqual(messages[0]["type"], "computer-info")
         self.assertNotEquals(len(messages[0]["hostname"]), 0)
-        self.assertTrue(re.search("\w", messages[0]["hostname"]))
+        self.assertTrue(re.search(r"\w", messages[0]["hostname"]))
 
     def test_only_report_changed_hostnames(self):
         self.mstore.set_accepted_types(["computer-info"])

--- a/landscape/client/package/releaseupgrader.py
+++ b/landscape/client/package/releaseupgrader.py
@@ -42,7 +42,7 @@ class ReleaseUpgrader(PackageTaskHandler):
         in the computer's sources.list it won't be commented out.
     @cvar logs_directory: Path to the directory holding the upgrade-tool logs.
     @cvar logs_limit: When reporting upgrade-tool logs to the server, only the
-        last C{logs_limit} lines will be sent.
+        last C{logs_limit} characters will be sent.
     """
 
     config_factory = ReleaseUpgraderConfiguration
@@ -50,7 +50,7 @@ class ReleaseUpgrader(PackageTaskHandler):
     lsb_release_filename = LSB_RELEASE_FILENAME
     landscape_ppa_url = "http://ppa.launchpad.net/landscape/trunk/ubuntu/"
     logs_directory = "/var/log/dist-upgrade"
-    logs_limit = 100000
+    logs_limit = 100000  # characters
 
     def make_operation_result_message(self, operation_id, status, text, code):
         """Convenience to create messages of type C{"operation-result"}."""
@@ -196,7 +196,7 @@ class ReleaseUpgrader(PackageTaskHandler):
             if not basename.endswith(".log"):
                 continue
             filename = os.path.join(self.logs_directory, basename)
-            content = read_text_file(filename, - self.logs_limit)
+            content = read_text_file(filename, -self.logs_limit)
             buf.write(u"=== %s ===\n\n%s\n\n" % (basename, content))
 
         return buf.getvalue()

--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -237,7 +237,7 @@ class PackageReporter(PackageTaskHandler):
                 with open(os.path.join(base, "status")) as fd:
                     read = fd.read()
 
-                pattern = re.compile('^Uid\:(.*)$',
+                pattern = re.compile(r'^Uid\:(.*)$',
                                      re.VERBOSE | re.MULTILINE)
 
                 for pattern in pattern.finditer(read):

--- a/landscape/lib/persist.py
+++ b/landscape/lib/persist.py
@@ -458,7 +458,7 @@ def path_tuple_to_string(path):
         if type(elem) is int:
             result[-1] += "[%d]" % elem
         else:
-            result.append(str(elem).replace(".", "\."))
+            result.append(str(elem).replace(".", r"\."))
     return ".".join(result)
 
 

--- a/landscape/lib/tag.py
+++ b/landscape/lib/tag.py
@@ -1,7 +1,7 @@
 import re
 
 
-_tag_check = re.compile("^\w+[\w-]*$", re.UNICODE)
+_tag_check = re.compile(r"^\w+[\w-]*$", re.UNICODE)
 
 
 def is_valid_tag(tagname):

--- a/landscape/lib/tests/test_fs.py
+++ b/landscape/lib/tests/test_fs.py
@@ -28,11 +28,11 @@ class ReadFileTest(BaseTestCase):
 
     def test_read_binary_file_with_limit(self):
         """
-        With a positive limit L{read_binary_file} reads only the bytes after
-        the given limit.
+        With a positive limit L{read_binary_file} reads up to L{limit} bytes
+        from the start of the file.
         """
         path = self.makeFile("foo bar")
-        self.assertEqual(read_binary_file(path, limit=3), b" bar")
+        self.assertEqual(read_binary_file(path, limit=3), b"foo")
 
     def test_read_binary_file_with_negative_limit(self):
         """
@@ -64,12 +64,12 @@ class ReadFileTest(BaseTestCase):
 
     def test_read_text_file_with_limit(self):
         """
-        With a positive limit L{read_text_file} returns only the characters
-        after the first L{limit} characters as string.
+        With a positive limit L{read_text_file} returns up to L{limit}
+        characters from the start of the file.
         """
         utf8_content = codecs.encode(u"foo \N{SNOWMAN}", "utf-8")
         path = self.makeFile(utf8_content, mode="wb")
-        self.assertEqual(read_text_file(path, limit=3), u" ☃")
+        self.assertEqual(read_text_file(path, limit=3), u"foo")
 
     def test_read_text_file_with_negative_limit(self):
         """

--- a/landscape/lib/tests/test_fs.py
+++ b/landscape/lib/tests/test_fs.py
@@ -90,6 +90,17 @@ class ReadFileTest(BaseTestCase):
         self.assertEqual(read_text_file(path, limit=100), u"foo ☃ bar")
         self.assertEqual(read_text_file(path, limit=-100), u"foo ☃ bar")
 
+    def test_read_text_file_with_broken_utf8(self):
+        """
+        A text file containing broken UTF-8 shouldn't cause an error, just
+        return some sensible replacement chars.
+        """
+        not_quite_utf8_content = b'foo \xca\xff bar'
+        path = self.makeFile(not_quite_utf8_content, mode='wb')
+        self.assertEqual(read_text_file(path), u'foo \ufffd\ufffd bar')
+        self.assertEqual(read_text_file(path, limit=5), u'foo \ufffd')
+        self.assertEqual(read_text_file(path, limit=-3), u'bar')
+
 
 class TouchFileTest(BaseTestCase):
 

--- a/landscape/lib/vm_info.py
+++ b/landscape/lib/vm_info.py
@@ -3,7 +3,7 @@ Network introspection utilities using ioctl and the /proc filesystem.
 """
 import os
 
-from landscape.lib.fs import read_text_file
+from landscape.lib.fs import read_binary_file, read_text_file
 
 
 def get_vm_info(root_path="/"):
@@ -59,24 +59,25 @@ def _is_vm_openvz(root_path):
 
 def _get_vm_by_vendor(sys_vendor_path):
     """Return the VM type byte string (possibly empty) based on the vendor."""
-    vendor = read_text_file(sys_vendor_path).lower()
     # Use lower-key string for vendors, since we do case-insentive match.
     # We need bytes here as required by the message schema.
+    vendor = read_binary_file(sys_vendor_path, limit=1024).lower()
 
     # 2018-01: AWS and DO are now returning custom sys_vendor names
     # instead of qemu. If this becomes a trend, it may be worth also checking
     # dmi/id/chassis_vendor which seems to unchanged (bochs).
     content_vendors_map = (
-        ("amazon ec2", b"kvm"),
-        ("bochs", b"kvm"),
-        ("digitalocean", b"kvm"),
-        ("google", b"gce"),
-        ("innotek", b"virtualbox"),
-        ("microsoft", b"hyperv"),
-        ("nutanix", b"kvm"),
-        ("openstack", b"kvm"),
-        ("qemu", b"kvm"),
-        ("vmware", b"vmware"))
+        (b"amazon ec2", b"kvm"),
+        (b"bochs", b"kvm"),
+        (b"digitalocean", b"kvm"),
+        (b"google", b"gce"),
+        (b"innotek", b"virtualbox"),
+        (b"microsoft", b"hyperv"),
+        (b"nutanix", b"kvm"),
+        (b"openstack", b"kvm"),
+        (b"qemu", b"kvm"),
+        (b"vmware", b"vmware"),
+    )
     for name, vm_type in content_vendors_map:
         if name in vendor:
             return vm_type


### PR DESCRIPTION
And while we're at it, clean up some of the mess in fs.py: there's
almost no circumstances where we want landscape client to fall over
because a text file has invalid UTF-8 (the original function before the
py2/3 split had no such circumstances that'd lead to decoding errors).
Furthermore, read_binary_file's limit was wrong when positive (not that
anything called it with a positive limit) and read_text_file defeated
the purpose of having a limit by permitting an arbitrarily large read
even when one was set.