### PR TITLE
Sysinfo: add support for multiple IPv4 addresses per interface

### DIFF
--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -29,17 +29,19 @@ def is_64():
 def get_active_interfaces():
     """Generator yields (active network interface name, address data) tuples.
 
-    Address data is formated exactly like L{netifaces.ifaddresses}, e.g.::
+    Address data is formatted exactly like L{netifaces.ifaddresses}, e.g.::
 
         ('eth0', {
             AF_LINK: [
                 {'addr': '...', 'broadcast': '...'}, ],
             AF_INET: [
                 {'addr': '...', 'broadcast': '...', 'netmask': '...'},
-                {'addr': '...', 'broadcast': '...', 'netmask': '...'}, ...],
+                {'addr': '...', 'broadcast': '...', 'netmask': '...'},
+                ...],
             AF_INET6: [
                 {'addr': '...', 'netmask': '...'},
-                {'addr': '...', 'netmask': '...'}, ...], })
+                {'addr': '...', 'netmask': '...'},
+                ...], })
 
     Interfaces with no IP address are ignored.
     """

--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -35,6 +35,14 @@ def get_active_interfaces():
             yield interface, ifaddresses
 
 
+def get_ip_addresses(interface):
+    results = {}
+    ifaddresses = netifaces.ifaddresses(interface)
+    if netifaces.AF_INET in ifaddresses:
+        results[netifaces.AF_INET] = ifaddresses[netifaces.AF_INET]
+    return results
+
+
 def get_broadcast_address(ifaddresses):
     """Return the broadcast address associated to an interface.
 
@@ -82,7 +90,7 @@ def get_flags(sock, interface):
 
 
 def get_active_device_info(skipped_interfaces=("lo",),
-                           skip_vlan=True, skip_alias=True):
+                           skip_vlan=True, skip_alias=True, extended=False):
     """
     Returns a dictionary containing information on each active network
     interface present on a machine.
@@ -104,6 +112,8 @@ def get_active_device_info(skipped_interfaces=("lo",),
             interface_info["broadcast_address"] = get_broadcast_address(
                 ifaddresses)
             interface_info["netmask"] = get_netmask(ifaddresses)
+            if extended:
+                interface_info["ip_addresses"] = get_ip_addresses(interface)
             interface_info["flags"] = get_flags(sock, interface.encode())
             speed, duplex = get_network_interface_speed(
                 sock, interface.encode())

--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -54,6 +54,14 @@ def get_active_interfaces():
 
 
 def get_ip_addresses(ifaddresses):
+    """Return a all IP addresses of an interfaces.
+
+    Returns the same structure as L{ifaddresses}, but filtered to keep
+    IP addresses only.
+
+    @param ifaddresses: a dict as returned by L{netifaces.ifaddresses} or
+        the address data in L{get_active_interfaces}'s output.
+    """
     results = {}
     if netifaces.AF_INET in ifaddresses:
         results[netifaces.AF_INET] = ifaddresses[netifaces.AF_INET]

--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -35,9 +35,8 @@ def get_active_interfaces():
             yield interface, ifaddresses
 
 
-def get_ip_addresses(interface):
+def get_ip_addresses(ifaddresses):
     results = {}
-    ifaddresses = netifaces.ifaddresses(interface)
     if netifaces.AF_INET in ifaddresses:
         results[netifaces.AF_INET] = ifaddresses[netifaces.AF_INET]
     return results
@@ -113,7 +112,7 @@ def get_active_device_info(skipped_interfaces=("lo",),
                 ifaddresses)
             interface_info["netmask"] = get_netmask(ifaddresses)
             if extended:
-                interface_info["ip_addresses"] = get_ip_addresses(interface)
+                interface_info["ip_addresses"] = get_ip_addresses(ifaddresses)
             interface_info["flags"] = get_flags(sock, interface.encode())
             speed, duplex = get_network_interface_speed(
                 sock, interface.encode())

--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -54,7 +54,7 @@ def get_active_interfaces():
 
 
 def get_ip_addresses(ifaddresses):
-    """Return a all IP addresses of an interfaces.
+    """Return all IP addresses of an interfaces.
 
     Returns the same structure as L{ifaddresses}, but filtered to keep
     IP addresses only.

--- a/landscape/sysinfo/sysinfo.py
+++ b/landscape/sysinfo/sysinfo.py
@@ -47,9 +47,7 @@ class SysInfoPluginRegistry(PluginRegistry):
     def add_header(self, name, value):
         """Add a new information header to be displayed to the user.
 
-        Each header name is only present once.  If a header is added
-        multiple times, the last value added will be returned in
-        the get_headers() call.
+        Header names can be repeated.
 
         Headers with value None are not returned by get_headers(), but
         they still allocate a position in the list.  This fact may be
@@ -61,7 +59,9 @@ class SysInfoPluginRegistry(PluginRegistry):
             self._header_index[name] = len(self._headers)
             self._headers.append((name, value))
         else:
-            self._headers[index] = (name, value)
+            index += 1
+            self._header_index[name] = index
+            self._headers.insert(index, (name, value))
 
     def get_headers(self):
         """Get all information headers to be displayed to the user.

--- a/landscape/sysinfo/tests/test_network.py
+++ b/landscape/sysinfo/tests/test_network.py
@@ -2,7 +2,7 @@ import unittest
 
 from landscape.lib.testing import TwistedTestCase
 from landscape.sysinfo.sysinfo import SysInfoPluginRegistry
-from landscape.sysinfo.network import Network
+from landscape.sysinfo.network import AF_INET, Network
 
 
 class NetworkTest(TwistedTestCase, unittest.TestCase):
@@ -18,15 +18,47 @@ class NetworkTest(TwistedTestCase, unittest.TestCase):
         """L{Network.run} always returns a succeeded C{Deferred}."""
         self.assertIs(None, self.successResultOf(self.network.run()))
 
-    def test_run_adds_header(self):
+    def test_run_single_interface_ipv4_address(self):
         """
         A header is written to sysinfo output for each network device reported
         by L{get_active_device_info}.
         """
-        self.result = [{"interface": "eth0", "ip_address": "192.168.0.50"}]
+        self.result = [{
+            "interface": "eth0",
+            "ip_address": "IGNORED",
+            "ip_addresses": {
+                AF_INET: [{"addr": "192.168.0.50"}]}}]
+
         self.network.run()
-        self.assertEqual([("IP address for eth0", "192.168.0.50")],
+        self.assertEqual([("IPv4 address for eth0", "192.168.0.50")],
                          self.sysinfo.get_headers())
+
+    def test_run_multiple_interface_multiple_addresses(self):
+        """
+        A header is written to sysinfo output for each network device reported
+        by L{get_active_device_info}.
+        """
+        self.result = [{
+            "interface": "eth0",
+            "ip_address": "IGNORED",
+            "ip_addresses": {
+                AF_INET: [
+                    {"addr": "192.168.0.50"},
+                    {"addr": "192.168.1.50"}]}}, {
+            "interface": "eth1",
+            "ip_address": "IGNORED",
+            "ip_addresses": {
+                AF_INET: [
+                    {"addr": "192.168.2.50"},
+                    {"addr": "192.168.3.50"}]}}]
+
+        self.network.run()
+        self.assertEqual([
+            ("IPv4 address for eth0", "192.168.0.50"),
+            ("IPv4 address for eth0", "192.168.1.50"),
+            ("IPv4 address for eth1", "192.168.2.50"),
+            ("IPv4 address for eth1", "192.168.3.50")],
+            self.sysinfo.get_headers())
 
     def test_run_without_network_devices(self):
         """

--- a/landscape/sysinfo/tests/test_sysinfo.py
+++ b/landscape/sysinfo/tests/test_sysinfo.py
@@ -44,6 +44,7 @@ class SysInfoPluginRegistryTest(HelperTestCase):
         self.sysinfo.add_header("Header2", "Value4")
         self.assertEqual(self.sysinfo.get_headers(),
                          [("Header1", "Value1"),
+                          ("Header2", "Value2"),
                           ("Header2", "Value4"),
                           ("Header3", "Value3")])
 


### PR DESCRIPTION
Prerequisite of [LP: #829379](https://bugs.launchpad.net/landscape-client/+bug/829379).
Sample output:
```
$ ./scripts/landscape-sysinfo
  System load:    2.32      Users logged in:       1
  Usage of /home: unknown   IPv4 address for eth0: 10.51.30.224
  Memory usage:   1%        IPv4 address for eth0: 172.16.102.1
  Swap usage:     0%        IPv4 address for eth1: 172.16.103.3
  Processes:      39        IPv4 address for eth1: 172.16.104.4
```
Depends on https://github.com/CanonicalLtd/landscape-client/pull/59.