### PR TITLE
 Sysinfo: add support for multiple IPv6 addresses per interface (LP: #829379)

### DIFF
--- a/landscape/sysinfo/network.py
+++ b/landscape/sysinfo/network.py
@@ -1,7 +1,7 @@
 from functools import partial
 from operator import itemgetter
 
-from netifaces import AF_INET
+from netifaces import AF_INET, AF_INET6
 from twisted.internet.defer import succeed
 
 from landscape.lib.network import get_active_device_info
@@ -36,10 +36,13 @@ class Network(object):
         device_info = self._get_device_info()
         for info in sorted(device_info, key=itemgetter('interface')):
             interface = info["interface"]
-
             ipv4_addresses = info["ip_addresses"].get(AF_INET, [])
+            ipv6_addresses = info["ip_addresses"].get(AF_INET6, [])
             for addr in ipv4_addresses:
                 self._sysinfo.add_header(
                     "IPv4 address for %s" % interface, addr['addr'])
+            for addr in ipv6_addresses:
+                self._sysinfo.add_header(
+                    "IPv6 address for %s" % interface, addr['addr'])
 
         return succeed(None)

--- a/landscape/sysinfo/tests/test_network.py
+++ b/landscape/sysinfo/tests/test_network.py
@@ -1,8 +1,10 @@
 import unittest
 
+from netifaces import AF_INET, AF_INET6
+
 from landscape.lib.testing import TwistedTestCase
 from landscape.sysinfo.sysinfo import SysInfoPluginRegistry
-from landscape.sysinfo.network import AF_INET, Network
+from landscape.sysinfo.network import Network
 
 
 class NetworkTest(TwistedTestCase, unittest.TestCase):
@@ -33,31 +35,56 @@ class NetworkTest(TwistedTestCase, unittest.TestCase):
         self.assertEqual([("IPv4 address for eth0", "192.168.0.50")],
                          self.sysinfo.get_headers())
 
+    def test_run_single_interface_ipv6_address(self):
+        self.result = [{
+            "interface": "eth0",
+            "ip_address": "IGNORED",
+            "ip_addresses": {
+                AF_INET6: [{"addr": "2001::1"}]}}]
+
+        self.network.run()
+        self.assertEqual([("IPv6 address for eth0", "2001::1")],
+                         self.sysinfo.get_headers())
+
     def test_run_multiple_interface_multiple_addresses(self):
         """
         A header is written to sysinfo output for each network device reported
         by L{get_active_device_info}.
         """
-        self.result = [{
-            "interface": "eth0",
-            "ip_address": "IGNORED",
-            "ip_addresses": {
-                AF_INET: [
-                    {"addr": "192.168.0.50"},
-                    {"addr": "192.168.1.50"}]}}, {
-            "interface": "eth1",
-            "ip_address": "IGNORED",
-            "ip_addresses": {
-                AF_INET: [
-                    {"addr": "192.168.2.50"},
-                    {"addr": "192.168.3.50"}]}}]
+        self.result = [
+            {
+                "interface": "eth0",
+                "ip_addresses": {
+                    AF_INET: [
+                        {"addr": "192.168.0.50"},
+                        {"addr": "192.168.1.50"}]},
+            }, {
+                "interface": "eth1",
+                "ip_addresses": {
+                    AF_INET: [
+                        {"addr": "192.168.2.50"},
+                        {"addr": "192.168.3.50"}],
+                    AF_INET6: [
+                        {"addr": "2001::1"},
+                        {"addr": "2002::2"}]},
+            }, {
+                "interface": "eth2",
+                "ip_addresses": {
+                    AF_INET6: [
+                        {"addr": "2003::3"},
+                        {"addr": "2004::4"}]},
+            }]
 
         self.network.run()
         self.assertEqual([
             ("IPv4 address for eth0", "192.168.0.50"),
             ("IPv4 address for eth0", "192.168.1.50"),
             ("IPv4 address for eth1", "192.168.2.50"),
-            ("IPv4 address for eth1", "192.168.3.50")],
+            ("IPv4 address for eth1", "192.168.3.50"),
+            ("IPv6 address for eth1", "2001::1"),
+            ("IPv6 address for eth1", "2002::2"),
+            ("IPv6 address for eth2", "2003::3"),
+            ("IPv6 address for eth2", "2004::4")],
             self.sysinfo.get_headers())
 
     def test_run_without_network_devices(self):


### PR DESCRIPTION
Fixes [LP: #829379](https://bugs.launchpad.net/landscape-client/+bug/829379).
Sample output:
```
$ ./scripts/landscape-sysinfo
  System load:     1.67      IPv4 address for eth0: 10.51.30.224
  Usage of /home:  unknown   IPv6 address for eth0: 2001::1
  Memory usage:    1%        IPv6 address for eth0: 2001:470:28:5b2::1
  Swap usage:      1%        IPv4 address for eth1: 172.16.103.3
  Processes:       35        IPv4 address for eth1: 172.16.104.4
  Users logged in: 1         IPv6 address for eth2: 2::1
```
Depends on https://github.com/CanonicalLtd/landscape-client/pull/61.