### PR TITLE
Networking fixes

### DIFF
--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -100,11 +100,11 @@ def get_netmask(ifaddresses):
     @param ifaddresses: a dict as returned by L{netifaces.ifaddresses} or
         the address data in L{get_active_interfaces}'s output.
     """
-    return ifaddresses[netifaces.AF_INET][0]['netmask']
+    return ifaddresses[netifaces.AF_INET][0].get('netmask', '')
 
 
 def get_ip_address(ifaddresses):
-    """Return the IP address associated to the interface.
+    """Return the first IPv4 address associated to the interface.
 
     @param ifaddresses: a dict as returned by L{netifaces.ifaddresses} or
         the address data in L{get_active_interfaces}'s output.
@@ -115,12 +115,15 @@ def get_ip_address(ifaddresses):
 def get_mac_address(ifaddresses):
     """
     Return the hardware MAC address for an interface in human friendly form,
-    ie. six colon separated groups of two hexadecimal digits.
+    ie. six colon separated groups of two hexadecimal digits, if available;
+    otherwise an empty string.
 
     @param ifaddresses: a dict as returned by L{netifaces.ifaddresses} or
         the address data in L{get_active_interfaces}'s output.
     """
-    return ifaddresses[netifaces.AF_LINK][0]['addr']
+    if netifaces.AF_LINK in ifaddresses:
+        return ifaddresses[netifaces.AF_LINK][0].get('addr', '')
+    return ''
 
 
 def get_flags(sock, interface):

--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -26,6 +26,15 @@ def is_64():
     return struct.calcsize("l") == 8
 
 
+def is_up(flags):
+    """Returns C{True} if the interface is up, otherwise C{False}.
+
+    @param flags: the integer value of an interface's flags.
+    @see /usr/include/linux/if.h for the meaning of the flags.
+    """
+    return flags & 1
+
+
 def get_active_interfaces():
     """Generator yields (active network interface name, address data) tuples.
 
@@ -143,8 +152,11 @@ def get_active_device_info(skipped_interfaces=("lo",),
                 continue
             if skip_alias and ":" in interface:
                 continue
+            flags = get_flags(sock, interface.encode())
+            if not is_up(flags):
+                continue
             interface_info = {"interface": interface}
-            interface_info["flags"] = get_flags(sock, interface.encode())
+            interface_info["flags"] = flags
             speed, duplex = get_network_interface_speed(
                 sock, interface.encode())
             interface_info["speed"] = speed

--- a/landscape/lib/tests/test_network.py
+++ b/landscape/lib/tests/test_network.py
@@ -15,7 +15,7 @@ from subprocess import Popen, PIPE
 from landscape.lib import testing
 from landscape.lib.network import (
     get_network_traffic, get_active_device_info, get_active_interfaces,
-    get_fqdn, get_network_interface_speed)
+    get_fqdn, get_network_interface_speed, is_up)
 
 
 class BaseTestCase(testing.HelperTestCase, unittest.TestCase):
@@ -71,7 +71,7 @@ class NetworkInfoTest(BaseTestCase):
     def test_extended_info(self, mock_interfaces, mock_ifaddresses,
                            mock_get_flags, mock_get_network_interface_speed):
         mock_get_network_interface_speed.return_value = (100, True)
-        mock_get_flags.return_value = "FLAGS"
+        mock_get_flags.return_value = 4163
         mock_interfaces.return_value = ["test_iface"]
         mock_ifaddresses.return_value = {
             AF_LINK: [
@@ -101,7 +101,7 @@ class NetworkInfoTest(BaseTestCase):
                     AF_INET6: [
                         {"addr": "2001::1"},
                         {"addr": "2002::2"}]},
-                'flags': 'FLAGS',
+                'flags': 4163,
                 'speed': 100,
                 'duplex': True}])
 
@@ -113,7 +113,7 @@ class NetworkInfoTest(BaseTestCase):
             self, mock_interfaces, mock_ifaddresses, mock_get_flags,
             mock_get_network_interface_speed):
         mock_get_network_interface_speed.return_value = (100, True)
-        mock_get_flags.return_value = "FLAGS"
+        mock_get_flags.return_value = 4163
         mock_interfaces.return_value = ["test_iface"]
         mock_ifaddresses.return_value = {
             AF_LINK: [{"addr": "aa:bb:cc:dd:ee:f0"}],
@@ -131,7 +131,7 @@ class NetworkInfoTest(BaseTestCase):
             self, mock_interfaces, mock_ifaddresses, mock_get_flags,
             mock_get_network_interface_speed):
         mock_get_network_interface_speed.return_value = (100, True)
-        mock_get_flags.return_value = "FLAGS"
+        mock_get_flags.return_value = 4163
         mock_interfaces.return_value = ["test_iface"]
         mock_ifaddresses.return_value = {
             AF_LINK: [{"addr": "aa:bb:cc:dd:ee:f0"}],
@@ -143,7 +143,7 @@ class NetworkInfoTest(BaseTestCase):
             device_info,
             [{
                 'interface': 'test_iface',
-                'flags': 'FLAGS',
+                'flags': 4163,
                 'speed': 100,
                 'duplex': True,
                 'ip_addresses': {AF_INET6: [{'addr': '2001::1'}]}}])
@@ -193,6 +193,23 @@ class NetworkInfoTest(BaseTestCase):
         interfaces = [i["interface"] for i in device_info]
         self.assertNotIn("test_iface", interfaces)
 
+    @patch("landscape.lib.network.get_network_interface_speed")
+    @patch("landscape.lib.network.get_flags")
+    @patch("landscape.lib.network.netifaces.ifaddresses")
+    @patch("landscape.lib.network.netifaces.interfaces")
+    def test_skip_iface_down(
+            self, mock_interfaces, mock_ifaddresses, mock_get_flags,
+            mock_get_network_interface_speed):
+        mock_get_network_interface_speed.return_value = (100, True)
+        mock_get_flags.return_value = 0
+        mock_interfaces.return_value = ["test_iface"]
+        mock_ifaddresses.return_value = {
+            AF_LINK: [{"addr": "aa:bb:cc:dd:ee:f0"}],
+            AF_INET: [{"addr": "192.168.1.50", "netmask": "255.255.255.0"}]}
+        device_info = get_active_device_info()
+        interfaces = [i["interface"] for i in device_info]
+        self.assertNotIn("test_iface", interfaces)
+
     def test_default_broadcast_addr(self):
         # lo has no broadcast address.
         self.assertNotIn("broadcast", _ifaddresses('lo')[AF_INET][0])
@@ -222,7 +239,7 @@ class NetworkInfoTest(BaseTestCase):
             self, mock_interfaces, mock_ifaddresses, mock_get_flags,
             mock_get_network_interface_speed):
         mock_get_network_interface_speed.return_value = (100, True)
-        mock_get_flags.return_value = "FLAGS"
+        mock_get_flags.return_value = 4163
         mock_interfaces.return_value = ["test_iface"]
         mock_ifaddresses.return_value = {
             AF_LINK: [
@@ -237,10 +254,17 @@ class NetworkInfoTest(BaseTestCase):
             device_info,
             [{
                 'interface': 'test_iface',
-                'flags': 'FLAGS',
+                'flags': 4163,
                 'speed': 100,
                 'duplex': True,
                 'ip_addresses': {AF_INET6: [{"addr": "2001::1"}]}}])
+
+    def test_is_up(self):
+        self.assertTrue(is_up(1))
+        self.assertTrue(is_up(1 + 2 + 64 + 4096))
+        self.assertFalse(is_up(0))
+        self.assertFalse(is_up(2 + 64 + 4096))
+        self.assertFalse(is_up(0b11111111111110))
 
 
 # exact output of cat /proc/net/dev snapshot with line continuations for pep8


### PR DESCRIPTION
- Ignore network interfaces that are not UP.
- Prevent crash on IPv4 network interface with no mac address (e.g. VPN `tun0`).
- Prevent crash on IPv4 network interface with no netmask (haven't really seen it IRL, but let's be defensive).