### PR TITLE
Set default value if data_path is missing. (LP: #1728681)

### DIFF
--- a/debian/landscape-client.postinst
+++ b/debian/landscape-client.postinst
@@ -102,6 +102,9 @@ END
         # user information.  The flag file will be removed by the client when
         # the update completes.
         DATA_PATH="`grep ^data_path /etc/landscape/client.conf | cut -d= -f2 | tr -d '[[:space:]]'`"
+        if [ -z "$DATA_PATH" ]; then
+            DATA_PATH=/var/lib/landscape/client
+        fi
         install --owner=landscape --directory $DATA_PATH
         USER_UPDATE_FLAG_FILE="$DATA_PATH/user-update-flag"
         install --owner=landscape /dev/null $USER_UPDATE_FLAG_FILE


### PR DESCRIPTION
Normally we set this in the default config, but older clients did not require
it at install and all clients run fine without it being explicitly set in the
config. Therefore this make the config line optional again.


Testing instructions:

dpkg-buildpackage -b
dpkg -i ../*.deb
sed -e /data_path/d -i /etc/landscape/client.conf<Paste>
dpkg -i ../*.deb