### PR TITLE
Replace removed calls from python-apt 1.9 (LP: #1850205)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 XSBC-Original-Maintainer: Landscape Team <landscape-team@canonical.com>
 Build-Depends: debhelper (>= 12), po-debconf, libdistro-info-perl,
                dh-python, python3-dev, python3-distutils-extra,
-               lsb-release, gawk, dh-systemd (>= 1.3)
+               lsb-release, gawk, dh-systemd (>= 1.3), net-tools
 Standards-Version: 4.4.0
 Homepage: https://github.com/CanonicalLtd/landscape-client
 

--- a/landscape/lib/apt/package/tests/test_facade.py
+++ b/landscape/lib/apt/package/tests/test_facade.py
@@ -358,15 +358,17 @@ class AptFacadeTest(testing.HelperTestCase, testing.FSTestCase,
               'components': 'main', 'distribution': 'lucid', 'type': 'deb'}],
             self.facade.get_channels())
 
-    def test_get_package_stanza(self):
+    def test_write_package_stanza(self):
         """
-        C{get_package_stanza} returns an entry for the package that can
+        C{write_package_stanza} returns an entry for the package that can
         be included in a Packages file.
         """
         deb_dir = self.makeDir()
         create_deb(deb_dir, PKGNAME1, PKGDEB1)
         deb_file = os.path.join(deb_dir, PKGNAME1)
-        stanza = self.facade.get_package_stanza(deb_file)
+        packages_file = os.path.join(deb_dir, "Packages")
+        with open(packages_file, "wb") as packages:
+            self.facade.write_package_stanza(deb_file, packages)
         SHA256 = (
             "f899cba22b79780dbe9bbbb802ff901b7e432425c264dc72e6bb20c0061e4f26")
         expected = textwrap.dedent("""\
@@ -392,7 +394,7 @@ class AptFacadeTest(testing.HelperTestCase, testing.FSTestCase,
              Description1
             """ % {"filename": PKGNAME1, "sha256": SHA256})
         expected = _parse_deb_stanza(expected)
-        stanza = _parse_deb_stanza(stanza)
+        stanza = _parse_deb_stanza(open(packages_file).read())
         self.assertEqual(expected, stanza)
 
     def test_add_channel_deb_dir_creates_packages_file(self):
@@ -404,9 +406,14 @@ class AptFacadeTest(testing.HelperTestCase, testing.FSTestCase,
         create_simple_repository(deb_dir)
         self.facade.add_channel_deb_dir(deb_dir)
         packages_contents = read_text_file(os.path.join(deb_dir, "Packages"))
-        expected_contents = "\n".join(
-            self.facade.get_package_stanza(os.path.join(deb_dir, pkg_name))
-            for pkg_name in [PKGNAME1, PKGNAME2, PKGNAME3])
+        stanzas = []
+        for pkg_name in [PKGNAME1, PKGNAME2, PKGNAME3]:
+            with open(self.makeFile(), "wb+", 0) as tmp:
+                self.facade.write_package_stanza(
+                    os.path.join(deb_dir, pkg_name), tmp)
+                tmp.seek(0)
+                stanzas.append(tmp.read().decode("utf-8"))
+        expected_contents = "\n".join(stanzas)
         self.assertEqual(expected_contents, packages_contents)
 
     def test_add_channel_deb_dir_get_packages(self):


### PR DESCRIPTION
This should resolve some obvious regressions  with python-apt 1.9 on both eoan and focal when trying to apply package profiles.

* added net-tools to build-deps, as it's not longer pre-seeded
* apt_pkg.rewrite_section by TagSection.write
* try call on removed fixer.install_protect() as it was deemed a NOOP in current version.

There is an additional test (test_change_package_holds) which still regresses. I've yet to determine the impact, but that will be addressed in a separate change.