### PR TITLE
Rename test held package to avoid conflicts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,20 @@ matrix:
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get -y install landscape-common"';
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo chown -R ubuntu:ubuntu /target"';
         - sg lxd -c 'lxc exec testcontainer -- sudo -i -u ubuntu sh -c "cd /target; make ${TARGET}" ubuntu';
-    - env: TARGET=check3 IMAGE=ubuntu-daily:bionic
+    - env: TARGET=check3 IMAGE=ubuntu:bionic
       script:
         # bionic needs cgroupv2 not on this kernel, so nudge the system a bit
         - sg lxd -c 'lxc exec testcontainer -- sh -c "dhclient eth0; cloud-init init"';
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get update && sudo apt-get -y install make python3-distutils-extra python3-mock python3-twisted python3-apt python-twisted-core python3-pycurl python3-netifaces"';
+        # creates user and dirs, some used through tests
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get -y install landscape-common"';
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo chown -R ubuntu:ubuntu /target"';
+        - sg lxd -c 'lxc exec testcontainer -- sudo -i -u ubuntu sh -c "cd /target; make ${TARGET}" ubuntu';
+    - env: TARGET=check3 IMAGE=ubuntu-daily:focal
+      script:
+        # bionic needs cgroupv2 not on this kernel, so nudge the system a bit
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "dhclient eth0; cloud-init init"';
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get update && sudo apt-get -y install make python3-distutils-extra python3-mock python3-twisted python3-apt python-twisted-core python3-pycurl python3-netifaces net-tools"';
         # creates user and dirs, some used through tests
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get -y install landscape-common"';
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo chown -R ubuntu:ubuntu /target"';

--- a/landscape/client/package/tests/test_changer.py
+++ b/landscape/client/package/tests/test_changer.py
@@ -916,13 +916,13 @@ class AptPackageChangerTest(LandscapeTest):
         message.
         """
         self._add_system_package("foo")
-        self._add_system_package("bar")
+        self._add_system_package("baz")
         self.facade.reload_channels()
         self._hash_packages_by_name(self.facade, self.store, "foo")
-        self._hash_packages_by_name(self.facade, self.store, "bar")
+        self._hash_packages_by_name(self.facade, self.store, "baz")
         [foo] = self.facade.get_packages_by_name("foo")
-        [bar] = self.facade.get_packages_by_name("bar")
-        self.facade.set_package_hold(bar)
+        [baz] = self.facade.get_packages_by_name("baz")
+        self.facade.set_package_hold(baz)
         # Make sure that the mtime of the dpkg status file is old when
         # apt loads it, so that it will be reloaded when asserting the
         # test result.
@@ -931,7 +931,7 @@ class AptPackageChangerTest(LandscapeTest):
         self.facade.reload_channels()
         self.store.add_task("changer", {"type": "change-packages",
                                         "hold": [foo.package.id],
-                                        "remove-hold": [bar.package.id],
+                                        "remove-hold": [baz.package.id],
                                         "operation-id": 123})
 
         def assert_result(result):

--- a/landscape/lib/apt/package/testing.py
+++ b/landscape/lib/apt/package/testing.py
@@ -46,15 +46,24 @@ class AptFacadeHelper(object):
             "Description": "short description\n " + description}
         package_stanza.update(control_fields)
 
-        # avoid deprecated apt_pkg.rewrite_section
-        with open(packages_file, "ab", 0) as dest:
-            dest.write(b"\n")
-            for key in apt_pkg.REWRITE_PACKAGE_ORDER:
-                try:
-                    dest.write(u"{}: {}\n".format(
-                        key, package_stanza[key]).encode("utf-8"))
-                except KeyError:
-                    pass
+        try:
+            with open(packages_file, "rb") as src:
+                packages = src.read().split(b"\n\n")
+        except IOError:
+            packages = []
+        if b"" in packages:
+            packages.remove(b"")
+
+        new_package = u"\n".join([
+            u"{}: {}".format(key, package_stanza[key])
+            for key in apt_pkg.REWRITE_PACKAGE_ORDER
+            if key in package_stanza
+        ]).encode("utf-8")
+        packages.append(new_package)
+
+        with open(packages_file, "wb", 0) as dest:
+            # keep Pacakges sorted to avoid odd behaviours like changing IDs.
+            dest.write(b"\n\n".join(sorted(packages)))
             dest.write(b"\n")
 
     def _add_system_package(self, name, architecture="all", version="1.0",


### PR DESCRIPTION
This should enable tests to pass on disco+, avoiding changing package IDs due:

* to an unsorted Packages file
* to package conflict with universe "bar" package

Also enable focal testing in travis, since they now pass.