### PR TITLE
Fix 'usage of /home: unknown' on WSL

### DIFF
--- a/landscape/lib/disk.py
+++ b/landscape/lib/disk.py
@@ -10,7 +10,7 @@ from twisted.python.compat import _PY3
 # List of filesystem types authorized when generating disk use statistics.
 STABLE_FILESYSTEMS = frozenset(
     ["ext", "ext2", "ext3", "ext4", "reiserfs", "ntfs", "msdos", "dos", "vfat",
-     "xfs", "hpfs", "jfs", "ufs", "hfs", "hfsplus", "simfs"])
+     "xfs", "hpfs", "jfs", "ufs", "hfs", "hfsplus", "simfs", "drvfs", "lxfs"])
 
 
 EXTRACT_DEVICE = re.compile("([a-z]+)[0-9]*")


### PR DESCRIPTION
File system types of `/home` and `/` on WSL are `drvfs` and `lxfs`.
So I just added these two fs-types to the "stable" fs-lists.
And now it can display the usage correctly :)