### PR TITLE
Override encoding in package-reporter.

### DIFF
--- a/landscape/client/broker/tests/test_transport.py
+++ b/landscape/client/broker/tests/test_transport.py
@@ -16,7 +16,7 @@ from twisted.internet.threads import deferToThread
 
 
 def sibpath(path):
-    return os.path.join(os.path.dirname(__file__), path)
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), path))
 
 
 PRIVKEY = sibpath("private.ssl")

--- a/landscape/client/package/reporter.py
+++ b/landscape/client/package/reporter.py
@@ -3,6 +3,7 @@ try:
 except ImportError:
     import urllib.parse as urlparse
 
+import locale
 import logging
 import time
 import os
@@ -866,6 +867,10 @@ class FakeReporter(PackageReporter):
 
 
 def main(args):
+    # Force UTF-8 encoding only for the reporter, thus allowing libapt-pkg to
+    # return unmangled descriptions.
+    locale.setlocale(locale.LC_CTYPE, ("C", "UTF-8"))
+
     if "FAKE_GLOBAL_PACKAGE_STORE" in os.environ:
         return run_task_handler(FakeGlobalReporter, args)
     elif "FAKE_PACKAGE_STORE" in os.environ:

--- a/landscape/client/package/tests/test_reporter.py
+++ b/landscape/client/package/tests/test_reporter.py
@@ -1,3 +1,4 @@
+import locale
 import sys
 import os
 import time
@@ -1230,6 +1231,31 @@ class PackageReporterAptTest(LandscapeTest):
             m.return_value = "RESULT"
             self.assertEqual("RESULT", main(["ARGS"]))
         m.assert_called_once_with(PackageReporter, ["ARGS"])
+
+    def test_main_resets_locale(self):
+        """
+        Reporter entry point should reset encoding to utf-8, as libapt-pkg
+        encodes description with system encoding and python-apt decodes
+        them as utf-8 (LP: #1827857).
+        """
+        self._add_package_to_deb_dir(
+            self.repository_dir, "gosa", description=u"GOsa\u00B2")
+        self.facade.reload_channels()
+
+        # Set the only non-utf8 locale which we're sure exists.
+        # It behaves slightly differently than the bug, but fails on the
+        # same condition.
+        locale.setlocale(locale.LC_CTYPE, (None, None))
+        self.addCleanup(locale.resetlocale)
+
+        with mock.patch("landscape.client.package.reporter.run_task_handler"):
+            main([])
+
+        # With the actual package, the failure will occur looking up the
+        # description translation.
+        pkg = self.facade.get_packages_by_name("gosa")[0]
+        skel = self.facade.get_package_skeleton(pkg, with_info=True)
+        self.assertEqual(u"GOsa\u00B2", skel.description)
 
     def test_find_reporter_command_with_bindir(self):
         self.config.bindir = "/spam/eggs"


### PR DESCRIPTION
This is a workaround for (LP: #1827857), where python3-apt incorrectly
assumes the encoding.