### PR TITLE
Clean up stale lock files

### DIFF
--- a/landscape/client/lockfile.py
+++ b/landscape/client/lockfile.py
@@ -1,0 +1,34 @@
+import errno
+import os
+
+from twisted.python import lockfile
+
+
+def patch_lockfile():
+    if lockfile.FilesystemLock is PatchedFilesystemLock:
+        return
+    lockfile.FilesystemLock = PatchedFilesystemLock
+
+
+class PatchedFilesystemLock(lockfile.FilesystemLock):
+    """
+    Patched Twisted's FilesystemLock.lock to handle PermissionError
+    when trying to lock.
+    """
+
+    def lock(self):
+        try:
+            return super(PatchedFilesystemLock, self).lock()
+        except OSError as e:
+            if e.errno != errno.EPERM:
+                raise
+            # XXX Ideally, twisted would name the process and check if
+            # processes match the expected name before killing them.
+            # Landscape-client runs as a separate user, so this issue should be
+            # mitigated, though it does get permission errors trying to kill a
+            # recycled PID. (LP: #1870087)
+            #
+            # Workaround is to remove the current lock file on such error and
+            # then retry locking.
+            os.remove(self.name)
+            return super(PatchedFilesystemLock, self).lock()

--- a/landscape/client/reactor.py
+++ b/landscape/client/reactor.py
@@ -2,6 +2,9 @@
 Extend the regular Twisted reactor with event-handling features.
 """
 from landscape.lib.reactor import EventHandlingReactor
+from landscape.client.lockfile import patch_lockfile
+
+patch_lockfile()
 
 
 class LandscapeReactor(EventHandlingReactor):

--- a/landscape/client/tests/test_amp.py
+++ b/landscape/client/tests/test_amp.py
@@ -214,6 +214,7 @@ class ComponentConnectorTest(LandscapeTest):
         # ensure stale lock was replaced
         self.assertNotEqual("1", os.readlink(lock_path))
         mock_kill.assert_not_called()
+        self.assertFalse(publisher._port.lockFile.clean)
 
         publisher.stop()
         reactor._cleanup()

--- a/landscape/client/tests/test_amp.py
+++ b/landscape/client/tests/test_amp.py
@@ -1,9 +1,11 @@
 import os
 import errno
+import subprocess
+import textwrap
 
 import mock
 
-from twisted.internet.error import ConnectError
+from twisted.internet.error import ConnectError, CannotListenError
 from twisted.internet.task import Clock
 
 from landscape.client.tests.helpers import LandscapeTest
@@ -167,13 +169,14 @@ class ComponentConnectorTest(LandscapeTest):
         self.connector.disconnect()
 
     @mock.patch("twisted.python.lockfile.kill")
-    def test_stale_locks_recycled_pid(self, mock_lock):
+    def test_stale_locks_with_dead_pid(self, mock_kill):
         """Publisher starts with stale lock."""
-        mock_lock.side_effect = [
-            OSError(errno.EPERM, "Operation not permitted"), False]
+        mock_kill.side_effect = [
+            OSError(errno.ESRCH, "No such process")]
         sock_path = os.path.join(self.config.sockets_path, u"test.sock")
         lock_path = u"{}.lock".format(sock_path)
-        os.symlink("0", lock_path)
+        # fake a PID which does not exist
+        os.symlink("-1", lock_path)
 
         component = TestComponent()
         # Test the actual Unix reactor implementation. Fakes won't do.
@@ -184,7 +187,62 @@ class ComponentConnectorTest(LandscapeTest):
         publisher.start()
 
         # ensure stale lock was replaced
-        self.assertNotEqual("0", os.readlink(lock_path))
+        self.assertNotEqual("-1", os.readlink(lock_path))
+        mock_kill.assert_called_with(-1, 0)
 
         publisher.stop()
+        reactor._cleanup()
+
+    @mock.patch("twisted.python.lockfile.kill")
+    def test_stale_locks_recycled_pid(self, mock_kill):
+        """Publisher starts with stale lock pointing to recycled process."""
+        mock_kill.side_effect = [
+            OSError(errno.EPERM, "Operation not permitted")]
+        sock_path = os.path.join(self.config.sockets_path, u"test.sock")
+        lock_path = u"{}.lock".format(sock_path)
+        # fake a PID recycled by a known process which isn't landscape (init)
+        os.symlink("1", lock_path)
+
+        component = TestComponent()
+        # Test the actual Unix reactor implementation. Fakes won't do.
+        reactor = LandscapeReactor()
+        publisher = ComponentPublisher(component, reactor, self.config)
+
+        # Shouldn't raise the exception.
+        publisher.start()
+
+        # ensure stale lock was replaced
+        self.assertNotEqual("1", os.readlink(lock_path))
+        mock_kill.assert_not_called()
+
+        publisher.stop()
+        reactor._cleanup()
+
+    @mock.patch("twisted.python.lockfile.kill")
+    def test_with_valid_lock(self, mock_kill):
+        """Publisher raises lock error if a valid lock is held."""
+        sock_path = os.path.join(self.config.sockets_path, u"test.sock")
+        lock_path = u"{}.lock".format(sock_path)
+        # fake a landscape process
+        app = self.makeFile(textwrap.dedent("""\
+            #!/usr/bin/python3
+            import time
+            time.sleep(10)
+        """), basename="landscape-manager")
+        os.chmod(app, 0o755)
+        call = subprocess.Popen([app])
+        self.addCleanup(call.terminate)
+        os.symlink(str(call.pid), lock_path)
+
+        component = TestComponent()
+        # Test the actual Unix reactor implementation. Fakes won't do.
+        reactor = LandscapeReactor()
+        publisher = ComponentPublisher(component, reactor, self.config)
+
+        with self.assertRaises(CannotListenError):
+            publisher.start()
+
+        # ensure lock was not replaced
+        self.assertEqual(str(call.pid), os.readlink(lock_path))
+        mock_kill.assert_called_with(call.pid, 0)
         reactor._cleanup()

--- a/landscape/client/tests/test_lockfile.py
+++ b/landscape/client/tests/test_lockfile.py
@@ -1,0 +1,21 @@
+import os
+import subprocess
+import textwrap
+
+from landscape.client import lockfile
+from landscape.client.tests.helpers import LandscapeTest
+
+
+class LockFileTest(LandscapeTest):
+
+    def test_read_process_name(self):
+        app = self.makeFile(textwrap.dedent("""\
+            #!/usr/bin/python3
+            import time
+            time.sleep(10)
+        """), basename="my_fancy_app")
+        os.chmod(app, 0o755)
+        call = subprocess.Popen([app])
+        self.addCleanup(call.terminate)
+        proc_name = lockfile.get_process_name(call.pid)
+        self.assertEqual("my_fancy_app", proc_name)


### PR DESCRIPTION
This change tries to clean up stale lock files, which points to dead processes. (LP: #1870087)

Testing instructions:

install/register client.
```
# systemctl stop landscape-client
# cd /var/lib/landscape/client/sockets/
# ln -sf 1 broker.sock.lock # make some fake locks pointing to live processes (1 is nice because it's always there and landscape should not have access to it)
# ln -sf 1 manager.sock.lock
# ln -sf 1 monitor.sock.lock
# systemctl start landscape-client
# ls -l cd /var/lib/landscape/client/sockets/
```
your fake locks should have been replaced by and point to valid PIDs (not 1).
You might as well check that lock conflicts do conflict while services are running:
```
# landscape-broker
twisted.internet.error.CannotListenError: Couldn't listen on any:b'/var/lib/landscape/client/sockets/broker.sock
```
