### PR TITLE
Add new optional config option script_output_limit

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -174,3 +174,11 @@ manager_plugins = ALL
 #
 # By default, all usernames are allowed.
 script_users = ALL
+
+
+# The maximum script output length transmitted to landscape
+# Output over this limit is truncated
+#
+# The default is 512kB
+# 2MB is allowed in this example
+#script_output_limit=2048

--- a/landscape/client/manager/config.py
+++ b/landscape/client/manager/config.py
@@ -30,12 +30,13 @@ class ManagerConfiguration(Configuration):
                           help="Comma-delimited list of usernames that scripts"
                                " may be run as. Default is to allow all "
                                "users.")
-        parser.add_option("--script-output-limit", metavar="SCRIPT_OUTPUT_LIMIT",
+        parser.add_option("--script-output-limit",
+                          metavar="SCRIPT_OUTPUT_LIMIT",
                           type="int", default=512,
-                          help="Maximum allowed output size that scripts can send (in kB)"
+                          help="Maximum allowed output size that scripts"
+                               " can send\n"
                                "Script output will be truncated at that limit."
                                "Default is 512 (kB)")
-
 
         return parser
 

--- a/landscape/client/manager/config.py
+++ b/landscape/client/manager/config.py
@@ -33,10 +33,10 @@ class ManagerConfiguration(Configuration):
         parser.add_option("--script-output-limit",
                           metavar="SCRIPT_OUTPUT_LIMIT",
                           type="int", default=512,
-                          help="Maximum allowed output size that scripts "
-                               "can send. "
-                               "Script output will be truncated at that limit. "
-                               "Default is 512 (kB)")
+                          help="Maximum allowed output size that scripts"
+                               " can send. "
+                               "Script output will be truncated at that limit."
+                               " Default is 512 (kB)")
 
         return parser
 

--- a/landscape/client/manager/config.py
+++ b/landscape/client/manager/config.py
@@ -33,9 +33,9 @@ class ManagerConfiguration(Configuration):
         parser.add_option("--script-output-limit",
                           metavar="SCRIPT_OUTPUT_LIMIT",
                           type="int", default=512,
-                          help="Maximum allowed output size that scripts"
-                               " can send."
-                               "Script output will be truncated at that limit."
+                          help="Maximum allowed output size that scripts "
+                               "can send. "
+                               "Script output will be truncated at that limit. "
                                "Default is 512 (kB)")
 
         return parser

--- a/landscape/client/manager/config.py
+++ b/landscape/client/manager/config.py
@@ -34,7 +34,7 @@ class ManagerConfiguration(Configuration):
                           metavar="SCRIPT_OUTPUT_LIMIT",
                           type="int", default=512,
                           help="Maximum allowed output size that scripts"
-                               " can send\n"
+                               " can send."
                                "Script output will be truncated at that limit."
                                "Default is 512 (kB)")
 

--- a/landscape/client/manager/config.py
+++ b/landscape/client/manager/config.py
@@ -30,6 +30,13 @@ class ManagerConfiguration(Configuration):
                           help="Comma-delimited list of usernames that scripts"
                                " may be run as. Default is to allow all "
                                "users.")
+        parser.add_option("--script-output-limit", metavar="SCRIPT_OUTPUT_LIMIT",
+                          type="int", default=512,
+                          help="Maximum allowed output size that scripts can send (in kB)"
+                               "Script output will be truncated at that limit."
+                               "Default is 512 (kB)")
+
+
         return parser
 
     @property

--- a/landscape/client/manager/scriptexecution.py
+++ b/landscape/client/manager/scriptexecution.py
@@ -115,7 +115,7 @@ class ScriptRunnerMixin(object):
         }
 
         pp = ProcessAccumulationProtocol(
-            self.registry.reactor, self.size_limit, self.truncation_indicator)
+            self.registry.reactor, self.registry.config.script_output_limit, self.truncation_indicator)
         args = (filename,)
         self.process_factory.spawnProcess(
             pp, filename, args=args, uid=uid, gid=gid, path=path, env=env)
@@ -127,10 +127,8 @@ class ScriptRunnerMixin(object):
 class ScriptExecutionPlugin(ManagerPlugin, ScriptRunnerMixin):
     """A plugin which allows execution of arbitrary shell scripts.
 
-    @ivar size_limit: The number of bytes at which to truncate process output.
     """
 
-    size_limit = 500000
 
     def register(self, registry):
         super(ScriptExecutionPlugin, self).register(registry)
@@ -316,7 +314,7 @@ class ProcessAccumulationProtocol(ProcessProtocol):
         self._size = 0
         self.result_deferred = Deferred()
         self._cancelled = False
-        self.size_limit = size_limit
+        self.size_limit = size_limit * 1024
         self._truncation_indicator = truncation_indicator.encode("utf-8")
         self._truncation_offset = len(self._truncation_indicator)
         self._truncated_size_limit = self.size_limit - self._truncation_offset

--- a/landscape/client/manager/scriptexecution.py
+++ b/landscape/client/manager/scriptexecution.py
@@ -115,7 +115,8 @@ class ScriptRunnerMixin(object):
         }
 
         pp = ProcessAccumulationProtocol(
-            self.registry.reactor, self.registry.config.script_output_limit, self.truncation_indicator)
+            self.registry.reactor, self.registry.config.script_output_limit,
+            self.truncation_indicator)
         args = (filename,)
         self.process_factory.spawnProcess(
             pp, filename, args=args, uid=uid, gid=gid, path=path, env=env)
@@ -128,7 +129,6 @@ class ScriptExecutionPlugin(ManagerPlugin, ScriptRunnerMixin):
     """A plugin which allows execution of arbitrary shell scripts.
 
     """
-
 
     def register(self, registry):
         super(ScriptExecutionPlugin, self).register(registry)

--- a/landscape/client/manager/tests/test_scriptexecution.py
+++ b/landscape/client/manager/tests/test_scriptexecution.py
@@ -492,8 +492,8 @@ class RunScriptTests(LandscapeTest):
         """Data returned from the command is limited."""
         factory = StubProcessFactory()
         self.plugin.process_factory = factory
-        result = self.plugin.run_script("/bin/sh", "")
         self.manager.config.script_output_limit = 1
+        result = self.plugin.run_script("/bin/sh", "")
 
         # Ultimately we assert that the resulting output is limited to
         # 1024 bytes and indicates its truncation.
@@ -503,7 +503,7 @@ class RunScriptTests(LandscapeTest):
         protocol = factory.spawns[0][0]
 
         # Push 2kB of output, so we trigger truncation.
-        protocol.childDataReceived(1, b"x" * 2*1024)
+        protocol.childDataReceived(1, b"x" * (2*1024))
 
         for fd in (0, 1, 2):
             protocol.childConnectionLost(fd)

--- a/landscape/client/manager/tests/test_scriptexecution.py
+++ b/landscape/client/manager/tests/test_scriptexecution.py
@@ -492,18 +492,18 @@ class RunScriptTests(LandscapeTest):
         """Data returned from the command is limited."""
         factory = StubProcessFactory()
         self.plugin.process_factory = factory
-        self.plugin.size_limit = 100
         result = self.plugin.run_script("/bin/sh", "")
+        self.manager.config.script_output_limit = 1
 
         # Ultimately we assert that the resulting output is limited to
-        # 100 bytes and indicates its truncation.
+        # 1024 bytes and indicates its truncation.
         result.addCallback(self.assertEqual,
-                           ("x" * 79) + "\n**OUTPUT TRUNCATED**")
+                           ("x" * (1024 - 21)) + "\n**OUTPUT TRUNCATED**")
 
         protocol = factory.spawns[0][0]
 
-        # Push 200 bytes of output, so we trigger truncation.
-        protocol.childDataReceived(1, b"x" * 200)
+        # Push 2kB of output, so we trigger truncation.
+        protocol.childDataReceived(1, b"x" * 2*1024)
 
         for fd in (0, 1, 2):
             protocol.childConnectionLost(fd)
@@ -515,19 +515,19 @@ class RunScriptTests(LandscapeTest):
         """After truncation, no further output is recorded."""
         factory = StubProcessFactory()
         self.plugin.process_factory = factory
-        self.plugin.size_limit = 100
+        self.manager.config.script_output_limit = 1
         result = self.plugin.run_script("/bin/sh", "")
 
         # Ultimately we assert that the resulting output is limited to
-        # 100 bytes and indicates its truncation.
+        # 1024 bytes and indicates its truncation.
         result.addCallback(self.assertEqual,
-                           ("x" * 79) + "\n**OUTPUT TRUNCATED**")
+                           ("x" * (1024 - 21)) + "\n**OUTPUT TRUNCATED**")
         protocol = factory.spawns[0][0]
 
-        # Push 200 bytes of output, so we trigger truncation.
-        protocol.childDataReceived(1, b"x" * 200)
-        # Push 200 bytes more
-        protocol.childDataReceived(1, b"x" * 200)
+        # Push 1024 bytes of output, so we trigger truncation.
+        protocol.childDataReceived(1, b"x" * 1024)
+        # Push 1024 bytes more
+        protocol.childDataReceived(1, b"x" * 1024)
 
         for fd in (0, 1, 2):
             protocol.childConnectionLost(fd)


### PR DESCRIPTION
Client side setting to make the script output size configurable.
This was hardcoded to 50000 (now 512kB default)