### PR TITLE
Set killmode on service.

### DIFF
--- a/debian/landscape-client.service
+++ b/debian/landscape-client.service
@@ -12,3 +12,5 @@ WantedBy=multi-user.target
 Type=simple
 Group=landscape
 ExecStart=/usr/bin/landscape-client
+# Don't kill cgroup as child dpkg may restart the service during an upgrade.
+KillMode=process


### PR DESCRIPTION
This keeps dpkg from killing itself through the whole cgroup when
landscape self-upgrades.