### PR TITLE
Add landscape-sysinfo CLI arg to specify maximum column width

### DIFF
--- a/landscape/sysinfo/deployment.py
+++ b/landscape/sysinfo/deployment.py
@@ -122,7 +122,7 @@ def run(args, reactor=None, sysinfo=None):
         print(format_sysinfo(headers=sysinfo.get_headers(),
                              notes=sysinfo.get_notes(),
                              footnotes=sysinfo.get_footnotes(),
-                             width=sysinfo.get_width(),
+                             width=config.width,
                              indent="  "))
 
     def run_sysinfo():

--- a/landscape/sysinfo/deployment.py
+++ b/landscape/sysinfo/deployment.py
@@ -49,7 +49,7 @@ class SysInfoConfiguration(BaseConfiguration):
                           help="Comma-delimited list of sysinfo plugins to "
                                "NOT use. This always take precedence over "
                                "plugins to include.")
-        
+
         parser.add_option("--width", type=int, default=80,
                           help="Maximum width for each column of output.")
 

--- a/landscape/sysinfo/deployment.py
+++ b/landscape/sysinfo/deployment.py
@@ -49,6 +49,9 @@ class SysInfoConfiguration(BaseConfiguration):
                           help="Comma-delimited list of sysinfo plugins to "
                                "NOT use. This always take precedence over "
                                "plugins to include.")
+        
+        parser.add_option("--width", type=int, default=80,
+                          help="Maximum width for each column of output.")
 
         parser.epilog = "Default plugins: %s" % (", ".join(ALL_PLUGINS))
         return parser
@@ -116,8 +119,11 @@ def run(args, reactor=None, sysinfo=None):
         sysinfo.add(plugin)
 
     def show_output(result):
-        print(format_sysinfo(sysinfo.get_headers(), sysinfo.get_notes(),
-                             sysinfo.get_footnotes(), indent="  "))
+        print(format_sysinfo(headers=sysinfo.get_headers(),
+                             notes=sysinfo.get_notes(),
+                             footnotes=sysinfo.get_footnotes(),
+                             width=sysinfo.get_width(),
+                             indent="  "))
 
     def run_sysinfo():
         return sysinfo.run().addCallback(show_output)

--- a/landscape/sysinfo/tests/test_deployment.py
+++ b/landscape/sysinfo/tests/test_deployment.py
@@ -119,11 +119,11 @@ class RunTest(HelperTestCase, ConfigTestCase, TwistedTestCase,
 
     @mock.patch("landscape.sysinfo.deployment.format_sysinfo")
     def test_format_sysinfo_gets_correct_information(self, format_sysinfo):
-        run(["--sysinfo-plugins", "TestPlugin"])
+        run(["--sysinfo-plugins", "TestPlugin", "--width", "100"])
         format_sysinfo.assert_called_once_with(
             [("Test header", "Test value")],
             ["Test note"], ["Test footnote"],
-            indent="  ")
+            width=100, indent="  ")
 
     def test_format_sysinfo_output_is_printed(self):
         with mock.patch(


### PR DESCRIPTION
Parsing the output of `landscape-sysinfo` is difficult across multiple system right now, as some systems will print output in two columns and others in one.  The simplest solution I could find to force it to always output 1 column is to pass a very low value to `format_sysinfo(..., width=1)` so that it always prints in one column.