### PR TITLE
Preserve auto flag on package changer operations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,11 @@ matrix:
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get -y install landscape-common"';
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo chown -R ubuntu:ubuntu /target"';
         - sg lxd -c 'lxc exec testcontainer -- sudo -i -u ubuntu sh -c "cd /target; make ${TARGET}" ubuntu';
-    - env: TARGET=check3 IMAGE=ubuntu-daily:focal
+    - env: TARGET=check3 IMAGE=ubuntu:focal
       script:
         # bionic needs cgroupv2 not on this kernel, so nudge the system a bit
         - sg lxd -c 'lxc exec testcontainer -- sh -c "dhclient eth0; cloud-init init"';
-        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get update && sudo apt-get -y install make python3-distutils-extra python3-mock python3-twisted python3-apt python-twisted-core python3-pycurl python3-netifaces net-tools"';
+        - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get update && sudo apt-get -y install make python3-distutils-extra python3-mock python3-twisted python3-apt python3-pycurl python3-netifaces net-tools"';
         # creates user and dirs, some used through tests
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo apt-get -y install landscape-common"';
         - sg lxd -c 'lxc exec testcontainer -- sh -c "sudo chown -R ubuntu:ubuntu /target"';

--- a/landscape/client/broker/tests/test_store.py
+++ b/landscape/client/broker/tests/test_store.py
@@ -149,7 +149,7 @@ class MessageStoreTest(LandscapeTest):
         for i in range(10):
             self.store.add(dict(type="data", data=intToBytes(i)))
         il = [m["data"] for m in self.store.get_pending_messages(5)]
-        self.assertEqual(il, [intToBytes(i) for i in[0, 1, 2, 3, 4]])
+        self.assertEqual(il, [intToBytes(i) for i in [0, 1, 2, 3, 4]])
 
     def test_offset(self):
         self.store.set_pending_offset(5)

--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -750,8 +750,8 @@ class AptFacade(object):
             # installed packages from auto-removal, while allowing upgrades
             # of auto-removable packages.
             is_manual = (
-                not version.package.installed
-                or not version.package.is_auto_installed)
+                not version.package.installed or
+                not version.package.is_auto_installed)
 
             # Set auto_fix=False to avoid removing the package we asked to
             # install when we need to resolve dependencies.

--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -744,9 +744,18 @@ class AptFacade(object):
             # Set the candidate version, so that the version we want to
             # install actually is the one getting installed.
             version.package.candidate = version
+
+            # Flag the package as manual if it's a new install, otherwise
+            # preserve the auto flag. This should preserve explicitly
+            # installed packages from auto-removal, while allowing upgrades
+            # of auto-removable packages.
+            is_manual = (
+                not version.package.installed
+                or not version.package.is_auto_installed)
+
             # Set auto_fix=False to avoid removing the package we asked to
             # install when we need to resolve dependencies.
-            version.package.mark_install(auto_fix=False)
+            version.package.mark_install(auto_fix=False, from_user=is_manual)
             self._package_installs.add(version.package)
             fixer.clear(version.package._pkg)
             fixer.protect(version.package._pkg)


### PR DESCRIPTION
This should address issues with package not autoremoved. (LP: #1878957)

Testing instructions:

In a new container
1. sudo ./scripts/landscape-client -c root-client.conf
2. wait for packages to synchronize to landscape-server
3. trigger an install of something new (e.g. sl)
4. trigger an upgrade/downgrade of something marked auto (e.g. tzdata)
5. trigger an upgrade/downgrade of something manual (e.g. bash)
6. check only the updated auto package is marked auto

```
$ apt-mark showmanual sl
sl

$ apt-mark showauto tzdata
tzdata

$ apt-mark showmanual bash
bash
```