### PR TITLE
decode registration error codes as str

### DIFF
--- a/landscape/client/broker/registration.py
+++ b/landscape/client/broker/registration.py
@@ -12,6 +12,7 @@ import logging
 
 from twisted.internet.defer import Deferred
 
+from landscape.client.broker.exchange import maybe_bytes
 from landscape.lib.juju import get_juju_info
 from landscape.lib.tag import is_valid_tag_list
 from landscape.lib.network import get_fqdn
@@ -239,8 +240,9 @@ class RegistrationHandler(object):
         self._reactor.fire("resynchronize-clients")
 
     def _handle_registration(self, message):
-        if message["info"] in ("unknown-account", "max-pending-computers"):
-            self._reactor.fire("registration-failed", reason=message["info"])
+        message_info = maybe_bytes(message["info"])
+        if message_info in ("unknown-account", "max-pending-computers"):
+            self._reactor.fire("registration-failed", reason=message_info)
 
     def _handle_unknown_id(self, message):
         id = self._identity

--- a/landscape/client/broker/tests/test_registration.py
+++ b/landscape/client/broker/tests/test_registration.py
@@ -90,7 +90,7 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         and insecure ids even if no requests were sent.
         """
         self.exchanger.handle_message(
-            {"type": "set-id", "id": "abc", "insecure-id": "def"})
+            {"type": b"set-id", "id": b"abc", "insecure-id": b"def"})
         self.assertEqual(self.identity.secure_id, "abc")
         self.assertEqual(self.identity.insecure_id, "def")
 
@@ -101,14 +101,14 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         """
         reactor_fire_mock = self.reactor.fire = mock.Mock()
         self.exchanger.handle_message(
-            {"type": "set-id", "id": "abc", "insecure-id": "def"})
+            {"type": b"set-id", "id": b"abc", "insecure-id": b"def"})
         reactor_fire_mock.assert_any_call("registration-done")
 
     def test_unknown_id(self):
         self.identity.secure_id = "old_id"
         self.identity.insecure_id = "old_id"
         self.mstore.set_accepted_types(["register"])
-        self.exchanger.handle_message({"type": "unknown-id"})
+        self.exchanger.handle_message({"type": b"unknown-id"})
         self.assertEqual(self.identity.secure_id, None)
         self.assertEqual(self.identity.insecure_id, None)
 
@@ -119,7 +119,8 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         """
         self.config.computer_title = "Wu"
         self.mstore.set_accepted_types(["register"])
-        self.exchanger.handle_message({"type": "unknown-id", "clone-of": "Wu"})
+        self.exchanger.handle_message(
+            {"type": b"unknown-id", "clone-of": "Wu"})
         self.assertEqual("Wu (clone)", self.config.computer_title)
         self.assertIn("Client is clone of computer Wu",
                       self.logfile.getvalue())
@@ -366,7 +367,7 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         """
         reactor_fire_mock = self.reactor.fire = mock.Mock()
         self.exchanger.handle_message(
-            {"type": "registration", "info": "unknown-account"})
+            {"type": b"registration", "info": b"unknown-account"})
         reactor_fire_mock.assert_called_with(
             "registration-failed", reason="unknown-account")
 
@@ -378,7 +379,7 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         """
         reactor_fire_mock = self.reactor.fire = mock.Mock()
         self.exchanger.handle_message(
-            {"type": "registration", "info": "max-pending-computers"})
+            {"type": b"registration", "info": b"max-pending-computers"})
         reactor_fire_mock.assert_called_with(
             "registration-failed", reason="max-pending-computers")
 
@@ -389,7 +390,7 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         """
         reactor_fire_mock = self.reactor.fire = mock.Mock()
         self.exchanger.handle_message(
-            {"type": "registration", "info": "blah-blah"})
+            {"type": b"registration", "info": b"blah-blah"})
         for name, args, kwargs in reactor_fire_mock.mock_calls:
             self.assertNotEquals("registration-failed", args[0])
 
@@ -420,13 +421,13 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
 
         # This should somehow callback the deferred.
         self.exchanger.handle_message(
-            {"type": "set-id", "id": "abc", "insecure-id": "def"})
+            {"type": b"set-id", "id": b"abc", "insecure-id": b"def"})
 
         self.assertEqual(calls, [1])
 
         # Doing it again to ensure that the deferred isn't called twice.
         self.exchanger.handle_message(
-            {"type": "set-id", "id": "abc", "insecure-id": "def"})
+            {"type": b"set-id", "id": b"abc", "insecure-id": b"def"})
 
         self.assertEqual(calls, [1])
 
@@ -448,7 +449,7 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
 
         # This should somehow callback the deferred.
         self.exchanger.handle_message(
-            {"type": "set-id", "id": "abc", "insecure-id": "def"})
+            {"type": b"set-id", "id": b"abc", "insecure-id": b"def"})
 
         self.assertEqual(results, [None])
 
@@ -473,13 +474,13 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
 
         # This should somehow callback the deferred.
         self.exchanger.handle_message(
-            {"type": "registration", "info": "unknown-account"})
+            {"type": b"registration", "info": b"unknown-account"})
 
         self.assertEqual(calls, [True])
 
         # Doing it again to ensure that the deferred isn't called twice.
         self.exchanger.handle_message(
-            {"type": "registration", "info": "unknown-account"})
+            {"type": b"registration", "info": b"unknown-account"})
 
         self.assertEqual(calls, [True])
 
@@ -505,13 +506,13 @@ class RegistrationHandlerTest(RegistrationHandlerTestBase):
         d.addErrback(add_call)
 
         self.exchanger.handle_message(
-            {"type": "registration", "info": "max-pending-computers"})
+            {"type": b"registration", "info": b"max-pending-computers"})
 
         self.assertEqual(calls, [True])
 
         # Doing it again to ensure that the deferred isn't called twice.
         self.exchanger.handle_message(
-            {"type": "registration", "info": "max-pending-computers"})
+            {"type": b"registration", "info": b"max-pending-computers"})
 
         self.assertEqual(calls, [True])
 


### PR DESCRIPTION
Fix a py3 regression where registration error codes are not passed to the landscape-config tool but instead gets a timeout.

Testing:
```
$ dpkg-buildpackage -b && sudo dpkg -i ../landscape-c*.deb
$ sudo landscape-config
$ sudo landscape-config --account-name invalid --silent --computer-title foo
Please wait...
Invalid account name or registration key.
$ sudo landscape-config --account-name standalone --silent --computer-title foo
Please wait...
('Maximum number of computers pending approval reached. ', 'Login to your Landscape server account page to manage pending computer approvals.')
```