### PR TITLE
Return missing deferred on service shutdown.

### DIFF
--- a/landscape/client/broker/service.py
+++ b/landscape/client/broker/service.py
@@ -82,10 +82,11 @@ class BrokerService(LandscapeService):
 
     def stopService(self):
         """Stop the broker."""
-        self.publisher.stop()
+        deferred = self.publisher.stop()
         self.exchanger.stop()
         self.pinger.stop()
         super(BrokerService, self).stopService()
+        return deferred
 
 
 def run(args):

--- a/landscape/client/manager/service.py
+++ b/landscape/client/manager/service.py
@@ -54,8 +54,9 @@ class ManagerService(LandscapeService):
     def stopService(self):
         """Stop the manager and close the connection with the broker."""
         self.connector.disconnect()
-        self.publisher.stop()
+        deferred = self.publisher.stop()
         super(ManagerService, self).stopService()
+        return deferred
 
 
 def run(args):

--- a/landscape/client/monitor/service.py
+++ b/landscape/client/monitor/service.py
@@ -56,10 +56,11 @@ class MonitorService(LandscapeService):
         The monitor is flushed to ensure that things like persist databases
         get saved to disk.
         """
-        self.publisher.stop()
+        deferred = self.publisher.stop()
         self.monitor.flush()
         self.connector.disconnect()
         super(MonitorService, self).stopService()
+        return deferred
 
 
 def run(args):


### PR DESCRIPTION
This should allow services to let their publisher shut down and clean
after itself, thus avoiding stale locks and sockets. (LP: #1870087)

### Testing instructions:

Spawn and stop the client. There should not be any lock or socket left.
```
sudo ./scripts/landscape-client -c root-client.conf
<ctrl-c>
ls -la /tmp/landscape-root/sockets/
<empty listing>
```