### PR TITLE
Scan /etc/apt/trusted.gpg.d when verifying release upgrade.

### DIFF
--- a/landscape/lib/gpg.py
+++ b/landscape/lib/gpg.py
@@ -1,5 +1,4 @@
 import itertools
-import os.path
 import shutil
 import tempfile
 

--- a/landscape/lib/gpg.py
+++ b/landscape/lib/gpg.py
@@ -1,5 +1,9 @@
+import itertools
+import os.path
 import shutil
 import tempfile
+
+from glob import glob
 
 from twisted.internet.utils import getProcessOutputAndValue
 
@@ -8,14 +12,15 @@ class InvalidGPGSignature(Exception):
     """Raised when the gpg signature for a given file is invalid."""
 
 
-def gpg_verify(filename, signature, gpg="/usr/bin/gpg"):
+def gpg_verify(filename, signature, gpg="/usr/bin/gpg", apt_dir="/etc/apt"):
     """Verify the GPG signature of a file.
 
     @param filename: Path to the file to verify the signature against.
     @param signature: Path to signature to use.
     @param gpg: Optionally, path to the GPG binary to use.
+    @param apt_dir: Optionally, path to apt trusted keyring.
     @return: a C{Deferred} resulting in C{True} if the signature is
-            valid, C{False} otherwise.
+             valid, C{False} otherwise.
         """
 
     def remove_gpg_home(ignored):
@@ -32,9 +37,17 @@ def gpg_verify(filename, signature, gpg="/usr/bin/gpg"):
                                       "code='%d')" % (gpg, out, err, code))
 
     gpg_home = tempfile.mkdtemp()
-    args = ("--no-options", "--homedir", gpg_home, "--no-default-keyring",
-            "--ignore-time-conflict", "--keyring", "/etc/apt/trusted.gpg",
-            "--verify", signature, filename)
+    keyrings = tuple(itertools.chain(*[
+        ("--keyring", keyring)
+        for keyring in sorted(
+            glob("{}/trusted.gpg".format(apt_dir)) +
+            glob("{}/trusted.gpg.d/*.gpg".format(apt_dir))
+        )
+    ]))
+    args = (
+        "--no-options", "--homedir", gpg_home, "--no-default-keyring",
+        "--ignore-time-conflict"
+    ) + keyrings + ("--verify", signature, filename)
 
     result = getProcessOutputAndValue(gpg, args=args)
     result.addBoth(remove_gpg_home)


### PR DESCRIPTION
This fixes a regression of bionic to focal upgrade. (lp:1903776)

Testing instructions:

* sudo apt build-dep . && dpkg-buildpackage -b
* install resulting packages inside a bionic container.
* register against landscape.c.c
* under Computers -> Packages, trigger a release upgrade (last link)
* Wait for activity success. Check `/var/log/landscape/release-upgrader.log`