### PR TITLE
Replace deprecated tostring() call with tobytes()

### DIFF
--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -246,7 +246,7 @@ def get_network_interface_speed(sock, interface_name):
     speed = -1
     try:
         fcntl.ioctl(sock, SIOCETHTOOL, packed)  # Status ioctl() call
-        res = status_cmd.tostring()
+        res = status_cmd.tobytes()
         speed, duplex = struct.unpack("12xHB28x", res)
     except (IOError, OSError) as e:
         if e.errno == errno.EPERM:

--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -11,7 +11,7 @@ import errno
 import logging
 
 import netifaces
-from twisted.python.compat import long
+from twisted.python.compat import long, _PY3
 
 __all__ = ["get_active_device_info", "get_network_traffic"]
 
@@ -246,7 +246,10 @@ def get_network_interface_speed(sock, interface_name):
     speed = -1
     try:
         fcntl.ioctl(sock, SIOCETHTOOL, packed)  # Status ioctl() call
-        res = status_cmd.tobytes()
+        if _PY3:
+            res = status_cmd.tobytes()
+        else:
+            res = status_cmd.tostring()
         speed, duplex = struct.unpack("12xHB28x", res)
     except (IOError, OSError) as e:
         if e.errno == errno.EPERM:


### PR DESCRIPTION
On booting a fresh hirsute daily image on a Raspberry Pi, the following appears in the MOTD:

```
=> There were exceptions while processing one or more plugins. See
/var/log/landscape/sysinfo.log for more information.
```

The log mentioned contains the following:

```
2021-02-19 15:27:28,062 ERROR    Network plugin raised an exception.
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/landscape/sysinfo/sysinfo.py", line 99, in run
    result = plugin.run()
  File "/usr/lib/python3/dist-packages/landscape/sysinfo/network.py", line 36, in run
    device_info = self._get_device_info()
  File "/usr/lib/python3/dist-packages/landscape/lib/network.py", line 163, in get_active_device_info
    speed, duplex = get_network_interface_speed(
  File "/usr/lib/python3/dist-packages/landscape/lib/network.py", line 249, in get_network_interface_speed
    res = status_cmd.tostring()
AttributeError: 'array.array' object has no attribute 'tostring'
```

Simply replacing the deprecated tostring() call with tobytes() fixes the issue and the MOTD message disappears.

[LP: #1911050](https://bugs.launchpad.net/ubuntu/+source/landscape-client/+bug/1911050)