### PR TITLE
Translate legacy py27 messages to py3 messages in broker server.

### DIFF
--- a/landscape/client/broker/tests/test_server.py
+++ b/landscape/client/broker/tests/test_server.py
@@ -130,6 +130,25 @@ class BrokerServerTest(LandscapeTest):
         self.assertMessages(self.mstore.get_pending_messages(), [message])
         self.assertTrue(self.exchanger.is_urgent())
 
+    def test_send_message_from_py27_upgrader(self):
+        """
+        If we receive release-upgrade results from a py27 release upgrader,
+        it gets translated to a py3-compatible message.
+        """
+        legacy_message = {
+            b"type": b"change-packages-result",
+            b"operation-id": 99,
+            b"result-code": 123}
+        self.mstore.set_accepted_types(["change-packages-result"])
+        self.broker.send_message(legacy_message, True)
+        expected = [{
+            "type": "change-packages-result",
+            "operation-id": 99,
+            "result-code": 123
+        }]
+        self.assertMessages(self.mstore.get_pending_messages(), expected)
+        self.assertTrue(self.exchanger.is_urgent())
+
     def test_is_pending(self):
         """
         The L{BrokerServer.is_pending} method indicates if a message with


### PR DESCRIPTION
This should address issues with upgrades never reporting back
when migrating to python3 while still having py27 processes. (LP: #1943291)

Testing instructions:

The quick and easy way to verify this is to
- apply [this patch](https://pastebin.ubuntu.com/p/YTbYjFrvNn/)
- edit `root-client.conf` to point to your preferred server
- then call `sudo ./scripts/landscape-client -c root-client.conf`
- then trigger a release upgrade (in the UI computer packages page, bottom-most link "release upgrade")
- and wait a few minutes for the NOOP update to succeed

The alternative would be to build the client package, create a local repo, and uncomment the extra source during the upgrade. 