### PR TITLE
Empty exchanges after sequence number jumping LP: #1917540

### DIFF
--- a/landscape/client/broker/exchange.py
+++ b/landscape/client/broker/exchange.py
@@ -351,7 +351,7 @@ from twisted.python.compat import _PY3
 
 from landscape.lib.fetch import HTTPCodeError, PyCurlError
 from landscape.lib.format import format_delta
-from landscape.lib.message import got_next_expected, ANCIENT
+from landscape.lib.message import got_next_expected, RESYNC
 from landscape.lib.versioning import is_version_higher, sort_versions
 
 from landscape import DEFAULT_SERVER_API, SERVER_API, CLIENT_API
@@ -746,9 +746,9 @@ class MessageExchange(object):
             next_expected += len(payload["messages"])
 
         message_store_state = got_next_expected(message_store, next_expected)
-        if message_store_state == ANCIENT:
-            # The server has probably lost some data we sent it. The
-            # slate has been wiped clean (by got_next_expected), now
+        if message_store_state == RESYNC:
+            # The server has probably lost some data we sent it. Or next
+            # expected is too high so the sequences are out of sync. Now
             # let's fire an event to tell all the plugins that they
             # ought to generate new messages so the server gets some
             # up-to-date data.

--- a/landscape/client/broker/tests/helpers.py
+++ b/landscape/client/broker/tests/helpers.py
@@ -39,14 +39,16 @@ class BrokerConfigurationHelper(object):
         log_dir = test_case.makeDir()
         test_case.config_filename = os.path.join(test_case.makeDir(),
                                                  "client.conf")
-        open(test_case.config_filename, "w").write(
-            "[client]\n"
-            "url = http://localhost:91919\n"
-            "computer_title = Some Computer\n"
-            "account_name = some_account\n"
-            "ping_url = http://localhost:91910\n"
-            "data_path = %s\n"
-            "log_dir = %s\n" % (data_path, log_dir))
+
+        with open(test_case.config_filename, "w") as fh:
+            fh.write(
+                "[client]\n"
+                "url = http://localhost:91919\n"
+                "computer_title = Some Computer\n"
+                "account_name = some_account\n"
+                "ping_url = http://localhost:91910\n"
+                "data_path = %s\n"
+                "log_dir = %s\n" % (data_path, log_dir))
 
         bootstrap_list.bootstrap(data_path=data_path, log_dir=log_dir)
 

--- a/landscape/client/broker/tests/test_exchange.py
+++ b/landscape/client/broker/tests/test_exchange.py
@@ -324,6 +324,89 @@ class MessageExchangeTest(LandscapeTest):
         self.assertEqual(payload["sequence"], 1)
         self.assertEqual(payload["next-expected-sequence"], 0)
 
+    @mock.patch("landscape.client.broker.store.MessageStore"
+                ".delete_old_messages")
+    def test_pending_offset_when_next_expected_too_high(self,
+                                                        mock_rm_all_messages):
+        '''
+        When next expected sequence received from server is too high, then the
+        pending offset should reset to zero. This will cause the client to
+        resend the payload.
+        '''
+
+        self.mstore.set_accepted_types(["data"])
+        self.mstore.add({"type": "data", "data": 0})
+        self.mstore.add({"type": "data", "data": 1})
+
+        self.exchanger.exchange()
+
+        self.assertEqual(self.mstore.get_pending_offset(), 2)
+
+        self.mstore.add({"type": "data", "data": 2})
+
+        self.transport.next_expected_sequence = 100
+
+        # Confirm pending offset is reset so that latest payload is sent again
+        self.exchanger.exchange()
+        self.assertEqual(self.mstore.get_pending_offset(), 0)
+
+        # This function advances the pending offset of the previous payload
+        # to the current one, otherwise an offset of 0 will resend two
+        # payloads
+        self.assertTrue(mock_rm_all_messages.called)
+
+    def test_payloads_when_next_expected_too_high(self):
+        '''
+        When next expected sequence received from server is too high, then the
+        current payload should get sent again since we don't have confirmation
+        that the server received it. Also previous payloads should not get
+        repeated.
+        '''
+
+        self.mstore.set_accepted_types(["data"])
+
+        message0 = {"type": "data", "data": 0}
+        self.mstore.add(message0)
+        self.exchanger.exchange()
+
+        message1 = {"type": "data", "data": 1}
+        message2 = {"type": "data", "data": 2}
+        self.mstore.add(message1)
+        self.mstore.add(message2)
+
+        self.transport.next_expected_sequence = 100
+        self.exchanger.exchange()  # Resync
+        self.exchanger.exchange()  # Resend
+
+        # Confirm messages is not empty which was the original bug
+        last_messages = self.transport.payloads[-1]["messages"]
+        self.assertTrue(last_messages)
+
+        # Confirm earlier payloads are not resent
+        self.assertNotIn(message0["data"],
+                         [m["data"] for m in last_messages])
+
+        # Confirm contents of payload
+        self.assertEqual([message1, message2], last_messages)
+
+    def test_resync_when_next_expected_too_high(self):
+        '''
+        When next expected sequence received from the server is too high, then
+        a resynchronize should happen
+        '''
+
+        self.mstore.set_accepted_types(["empty", "resynchronize"])
+        self.mstore.add({"type": "empty"})
+        self.exchanger.exchange()
+
+        self.transport.next_expected_sequence = 100
+
+        self.reactor.call_on("resynchronize-clients", lambda scope=None: None)
+
+        self.exchanger.exchange()
+        self.assertMessages(self.mstore.get_pending_messages(),
+                            [{"type": "resynchronize"}])
+
     def test_start_with_urgent_exchange(self):
         """
         Immediately after registration, an urgent exchange should be scheduled.

--- a/landscape/lib/message.py
+++ b/landscape/lib/message.py
@@ -1,6 +1,6 @@
 """Helpers for reliable persistent message queues."""
 
-ANCIENT = 1
+RESYNC = 1
 
 
 def got_next_expected(store, next_expected):
@@ -9,6 +9,12 @@ def got_next_expected(store, next_expected):
     Call this with the message store and sequence number that the peer
     wants next; this will do various things based on what *this* side
     has in its outbound queue store.
+
+    0. The peer expects a sequence number greater than the number of messages
+       we just sent. This means something is not right. We advance the pending
+       offset from the previous payload since the server does not want old or
+       ancient messages, however we also reset it so that current payload is 
+       resent. Then we resynchronize by calling RESYNC. See LP: #1917540
 
     1. The peer expects a sequence greater than what we last
        sent. This is the common case and generally it should be
@@ -25,18 +31,22 @@ def got_next_expected(store, next_expected):
        from that message.
 
     If the next expected sequence from the server refers to a message
-    older than we have, then L{ANCIENT} will be returned.
+    older than we have, then L{RESYNC} will be returned.
     """
     ret = None
     old_sequence = store.get_sequence()
-    if next_expected > old_sequence:
+    if (next_expected - old_sequence) > store.count_pending_messages():
+        store.delete_old_messages()  # This will advance prev pending offset
+        pending_offset = 0  # This means current messages will be resent
+        ret = RESYNC
+    elif next_expected > old_sequence:
         store.delete_old_messages()
         pending_offset = next_expected - old_sequence
     elif next_expected < (old_sequence - store.get_pending_offset()):
         # "Ancient": The other side wants messages we don't have,
         # so let's just reset our counter to what it expects.
         pending_offset = 0
-        ret = ANCIENT
+        ret = RESYNC
     else:
         # No messages transferred, or
         # "Old": We'll try to send these old messages that the
@@ -47,3 +57,4 @@ def got_next_expected(store, next_expected):
     store.set_pending_offset(pending_offset)
     store.set_sequence(next_expected)
     return ret
+

--- a/landscape/lib/message.py
+++ b/landscape/lib/message.py
@@ -13,7 +13,7 @@ def got_next_expected(store, next_expected):
     0. The peer expects a sequence number greater than the number of messages
        we just sent. This means something is not right. We advance the pending
        offset from the previous payload since the server does not want old or
-       ancient messages, however we also reset it so that current payload is 
+       ancient messages, however we also reset it so that current payload is
        resent. Then we resynchronize by calling RESYNC. See LP: #1917540
 
     1. The peer expects a sequence greater than what we last
@@ -57,4 +57,3 @@ def got_next_expected(store, next_expected):
     store.set_pending_offset(pending_offset)
     store.set_sequence(next_expected)
     return ret
-


### PR DESCRIPTION
From here https://bugs.launchpad.net/landscape-client/+bug/1917540