### PR TITLE
Fixes import issues with jammy. (LP: #1962539)

### DIFF
--- a/landscape/client/broker/exchange.py
+++ b/landscape/client/broker/exchange.py
@@ -347,7 +347,7 @@ import logging
 from landscape.lib.hashlib import md5
 
 from twisted.internet.defer import Deferred, succeed
-from twisted.python.compat import _PY3
+from landscape.lib.compat import _PY3
 
 from landscape.lib.fetch import HTTPCodeError, PyCurlError
 from landscape.lib.format import format_delta

--- a/landscape/client/broker/server.py
+++ b/landscape/client/broker/server.py
@@ -46,7 +46,7 @@ Diagram::
 import logging
 
 from twisted.internet.defer import Deferred
-from twisted.python.compat import _PY3
+from landscape.lib.compat import _PY3
 
 from landscape.lib.twisted_util import gather_results
 from landscape.client.amp import remote

--- a/landscape/client/broker/tests/test_registration.py
+++ b/landscape/client/broker/tests/test_registration.py
@@ -3,7 +3,7 @@ import logging
 import socket
 import mock
 
-from twisted.python.compat import _PY3
+from landscape.lib.compat import _PY3
 
 from landscape.client.broker.registration import RegistrationError, Identity
 from landscape.client.tests.helpers import LandscapeTest

--- a/landscape/client/broker/transport.py
+++ b/landscape/client/broker/transport.py
@@ -6,7 +6,7 @@ import uuid
 
 import pycurl
 
-from twisted.python.compat import unicode, _PY3
+from landscape.lib.compat import unicode, _PY3
 
 from landscape.lib import bpickle
 from landscape.lib.fetch import fetch

--- a/landscape/client/manager/keystonetoken.py
+++ b/landscape/client/manager/keystonetoken.py
@@ -1,7 +1,7 @@
 import os
 import logging
 
-from twisted.python.compat import _PY3
+from landscape.lib.compat import _PY3
 
 from landscape.lib.compat import ConfigParser, NoOptionError
 from landscape.client.monitor.plugin import DataWatcher

--- a/landscape/client/user/provider.py
+++ b/landscape/client/user/provider.py
@@ -4,7 +4,7 @@ import csv
 import logging
 import subprocess
 
-from twisted.python.compat import _PY3
+from landscape.lib.compat import _PY3
 
 
 class UserManagementError(Exception):

--- a/landscape/lib/apt/package/skeleton.py
+++ b/landscape/lib/apt/package/skeleton.py
@@ -1,8 +1,7 @@
+from landscape.lib.compat import unicode, _PY3
 from landscape.lib.hashlib import sha1
 
 import apt_pkg
-
-from twisted.python.compat import unicode, _PY3
 
 
 PACKAGE   = 1 << 0

--- a/landscape/lib/base64.py
+++ b/landscape/lib/base64.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from twisted.python.compat import _PY3
+from landscape.lib.compat import _PY3
 
 if _PY3:
     from base64 import decodebytes  # noqa

--- a/landscape/lib/bpickle.py
+++ b/landscape/lib/bpickle.py
@@ -32,7 +32,7 @@ This file is modified from the original to work with python3, but should be
 wire compatible and behave the same way (bugs notwithstanding).
 """
 
-from twisted.python.compat import _PY3
+from landscape.lib.compat import long, _PY3
 
 dumps_table = {}
 loads_table = {}

--- a/landscape/lib/compat.py
+++ b/landscape/lib/compat.py
@@ -1,6 +1,6 @@
 # flake8: noqa
 
-from twisted.python.compat import _PY3
+_PY3 = str != bytes
 
 
 if _PY3:
@@ -13,6 +13,8 @@ if _PY3:
     from io import StringIO
     stringio = cstringio = StringIO
     from builtins import input
+    unicode = str
+    long = int
 
 else:
     import cPickle
@@ -24,3 +26,5 @@ else:
     stringio = StringIO
     from cStringIO import StringIO as cstringio
     input = raw_input
+    long = long
+    unicode = unicode

--- a/landscape/lib/disk.py
+++ b/landscape/lib/disk.py
@@ -4,7 +4,7 @@ import os
 import re
 import codecs
 
-from twisted.python.compat import _PY3
+from landscape.lib.compat import _PY3
 
 
 # List of filesystem types authorized when generating disk use statistics.

--- a/landscape/lib/network.py
+++ b/landscape/lib/network.py
@@ -11,7 +11,7 @@ import errno
 import logging
 
 import netifaces
-from twisted.python.compat import long, _PY3
+from landscape.lib.compat import long, _PY3
 
 __all__ = ["get_active_device_info", "get_network_traffic"]
 

--- a/landscape/lib/testing.py
+++ b/landscape/lib/testing.py
@@ -15,7 +15,7 @@ import unittest
 from logging import Handler, ERROR, Formatter
 from twisted.trial.unittest import TestCase
 from twisted.python.compat import StringType as basestring
-from twisted.python.compat import _PY3
+from landscape.lib.compat import _PY3
 from twisted.python.failure import Failure
 from twisted.internet.defer import Deferred
 from twisted.internet.error import ConnectError

--- a/landscape/lib/user.py
+++ b/landscape/lib/user.py
@@ -1,7 +1,7 @@
 import os.path
 import pwd
 
-from twisted.python.compat import _PY3
+from landscape.lib.compat import _PY3
 
 from landscape.lib.encoding import encode_if_needed
 


### PR DESCRIPTION
* replace deprecated twisted _PY3
* replace legacy types which are gone (unicode, long)

Testing instructions:

For the bug itself, running `./scripts/landscape-sysinfo` from within a
jammy container should be sufficient.
Since this branch touches practically every code path, I would recommend
fully launching the client and registering it.
