### PR TITLE
d/landscape-sysinfo.wrapper: avoid too frequent expensive operations …

### DIFF
--- a/debian/landscape-common.postrm
+++ b/debian/landscape-common.postrm
@@ -41,6 +41,12 @@ case "$1" in
 
         LOG_DIR=/var/log/landscape
         rm -f "${LOG_DIR}/sysinfo.log"*
+
+        #########################################
+        # from landscape-common
+
+        CACHE_FILE="/var/lib/landscape/landscape-sysinfo.cache"
+        rm -f "${CACHE_FILE}"
     ;;
 
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)

--- a/debian/landscape-sysinfo.wrapper
+++ b/debian/landscape-sysinfo.wrapper
@@ -1,17 +1,29 @@
 #!/bin/sh
-# pam_motd does not carry the environment
-[ -f /etc/default/locale ] && . /etc/default/locale
-export LANG
-cores=$(grep -c ^processor /proc/cpuinfo 2>/dev/null)
-[ "$cores" -eq "0" ] && cores=1
-threshold="${cores:-1}.0"
-if [ $(echo "`cut -f1 -d ' ' /proc/loadavg` < $threshold" | bc) -eq 1 ]; then
-    echo
-    echo -n "  System information as of "
-    /bin/date
-    echo
-    /usr/bin/landscape-sysinfo
-else
-    echo
-    echo " System information disabled due to load higher than $threshold"
+
+# don't try refresh this more than once per minute
+# Due to cpu consumption and login delays (LP: #1893716)
+stamp="/var/lib/landscape/landscape-sysinfo.cache"
+NEED_UPDATE="FALSE"
+[ -z "$(find "$stamp" -newermt 'now-1 minutes' 2> /dev/null)" ] && NEED_UPDATE="TRUE"
+
+if [ "$NEED_UPDATE" = "TRUE" ]; then
+    # pam_motd does not carry the environment
+    [ -f /etc/default/locale ] && . /etc/default/locale
+    export LANG
+    cores=$(grep -c ^processor /proc/cpuinfo 2>/dev/null)
+    [ "$cores" -eq "0" ] && cores=1
+    threshold="${cores:-1}.0"
+    if [ $(echo "`cut -f1 -d ' ' /proc/loadavg` < $threshold" | bc) -eq 1 ]; then
+        printf "\n  System information as of %s\n\n%s\n" \
+            "$(/bin/date)" \
+            "$(/usr/bin/landscape-sysinfo)" \
+            > "$stamp"
+    else
+        # do not replace a formerly good result due to load
+        if ! grep -q "System information as of" $stamp 2> /dev/null; then
+            printf "\n System information disabled due to load higher than %s\n" "$threshold" > "$stamp"
+        fi
+    fi
 fi
+
+[ ! -r "$stamp" ] || cat "$stamp"


### PR DESCRIPTION
See [LP: #1893716](https://bugs.launchpad.net/ubuntu/+source/landscape-client/+bug/1893716)

- use a cache file and refresh it only once per minute
- if the former info was not useful (skipped due to load) do still wait,
  but only 5 seconds
- if the former info was useful and we'd replace it with "sorry, load to
  high" skip that update