### PR TITLE
Use systemctl to signal post-logrotate.

### DIFF
--- a/debian/landscape-client.logrotate
+++ b/debian/landscape-client.logrotate
@@ -5,8 +5,9 @@
     notifempty
     compress
     nocreate
+    sharedscripts
     postrotate
-        [ -f /var/run/landscape/landscape-client.pid ] && kill -s USR1 `cat /var/run/landscape/landscape-client.pid` > /dev/null 2>&1 || :
+        systemctl kill --signal=USR1 --kill-who=main landscape-client > /dev/null 2>&1 || :
     endscript
 }
 


### PR DESCRIPTION
Use systemctl to signal parent process instead of using pidfile (LP: #1968189)
Only signal once for all rotations.

Testing instructions:

```
apt-get build-dep .
dpkg-buildpackage -b
dpkg -i ../landscape*.deb
systemctl start landscape-client  # it's unconfigured, but this is fine.
tail -F /var/log/landscape/*.log &
logrotate --force /etc/logrotate.conf  
```
You'll get a  couple of outputs, one per landscape process log, telling the log files were rotated.