### PR TITLE
Disable stopping service during upgrade.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -23,4 +23,4 @@ override_dh_auto_install:
 	install -D -o root -g root -m 755 apt-update/apt-update $(CURDIR)/$(root_dir)$(LIBDIR)/apt-update
 
 override_dh_installsystemd:
-	dh_installsystemd --no-enable --no-start
+	dh_installsystemd --no-enable --no-start --no-stop-on-upgrade


### PR DESCRIPTION
The client package using no-start (due to being enabled from
landscape-config), avoid stopping the service on upgrade so that

1. landscape may upgrade itself and see the upgrade complete
2. the client doesn't stay down after upgrade (due to no-start, dh will never restart it)