### PR TITLE
Added initial support for risc-v processor family

### DIFF
--- a/landscape/client/monitor/processorinfo.py
+++ b/landscape/client/monitor/processorinfo.py
@@ -87,7 +87,7 @@ class ProcessorInfo(MonitorPlugin):
                     dirty = True
 
         if dirty:
-            logging.info("Queueing message with updated processor info.  Contents:")
+            logging.info("Queueing updated processor info.  Contents:")
             logging.info(message)
             self.registry.broker.send_message(
                 message, self._session_id, urgent=urgent)


### PR DESCRIPTION
This adds support so that the landscape client can successfully run on a riscv processor.  it was tested on a VisionFive v1 board against the beta Landscape client.