### PR TITLE
Replace dependency on /etc/lsb-release with /usr/bin/lsb_release to permit Debian compatibility - #1990268

### DIFF
--- a/landscape/client/package/releaseupgrader.py
+++ b/landscape/client/package/releaseupgrader.py
@@ -37,7 +37,7 @@ class ReleaseUpgrader(PackageTaskHandler):
     @cvar config_factory: The configuration class to use to build configuration
         objects to be passed to our constructor.
     @cvar queue_name: The queue we pick tasks from.
-    @cvar lsb_release_filename: The path to the LSB data on the file system.
+    @cvar lsb_release_filename: The path to the LSB command on the file system.
     @cvar landscape_ppa_url: The URL of the Landscape PPA, if it is present
         in the computer's sources.list it won't be commented out.
     @cvar logs_directory: Path to the directory holding the upgrade-tool logs.

--- a/landscape/client/package/releaseupgrader.py
+++ b/landscape/client/package/releaseupgrader.py
@@ -37,7 +37,7 @@ class ReleaseUpgrader(PackageTaskHandler):
     @cvar config_factory: The configuration class to use to build configuration
         objects to be passed to our constructor.
     @cvar queue_name: The queue we pick tasks from.
-    @cvar lsb_release_filename: The path to the LSB command on the file system.
+    @cvar lsb_release_filename: The path to the LSB data on the file system.
     @cvar landscape_ppa_url: The URL of the Landscape PPA, if it is present
         in the computer's sources.list it won't be commented out.
     @cvar logs_directory: Path to the directory holding the upgrade-tool logs.

--- a/landscape/client/package/tests/test_taskhandler.py
+++ b/landscape/client/package/tests/test_taskhandler.py
@@ -1,4 +1,5 @@
 import os
+from subprocess import CalledProcessError
 
 from mock import patch, Mock, ANY
 
@@ -103,7 +104,9 @@ class PackageTaskHandlerTest(LandscapeTest):
         self.handler.lsb_release_filename = self.makeFile()
 
         # Go!
-        result = self.handler.use_hash_id_db()
+        with patch("landscape.lib.lsb_release.check_output") as co_mock:
+            co_mock.side_effect = CalledProcessError(127, "")
+            result = self.handler.use_hash_id_db()
 
         # The failure should be properly logged
         logging_mock.assert_called_with(

--- a/landscape/lib/lsb_release.py
+++ b/landscape/lib/lsb_release.py
@@ -1,19 +1,58 @@
 """Get information from /usr/bin/lsb_release."""
+import os
+from subprocess import DEVNULL, CalledProcessError, check_output
 
-LSB_RELEASE_FILENAME = "/usr/bin/lsb_release"
-LSB_RELEASE_INFO_KEYS = {"distributor-id": "-si",
-                         "release": "-sr",
-                         "code-name": "-sc",
-                         "description": "-sd"}
+LSB_RELEASE = "/usr/bin/lsb_release"
+LSB_RELEASE_FILENAME = "/etc/lsb_release"
+LSB_RELEASE_FILE_KEYS = {
+    "DISTRIB_ID": "distributor-id",
+    "DISTRIB_DESCRIPTION": "description",
+    "DISTRIB_RELEASE": "release",
+    "DISTRIB_CODENAME": "code-name",
+}
 
-import subprocess
 
-def parse_lsb_release(lsb_release_filename):
-    """Return a C{dict} holding information about the system LSB release.
-    @raises: An OSError exception if C{lsb_release_filename} does not exist.
+def parse_lsb_release(lsb_release_filename=None):
+    """
+    Returns a C{dict} holding information about the system LSB release.
+    Reads from C{lsb_release_filename} if it exists, else calls
+    C{LSB_RELEASE}
+    """
+    if lsb_release_filename and os.path.exists(lsb_release_filename):
+        return parse_lsb_release_file(lsb_release_filename)
+
+    try:
+        lsb_info = check_output([LSB_RELEASE, "-as"], stderr=DEVNULL)
+    except CalledProcessError:
+        # Fall back to reading file, even if it doesn't exist.
+        return parse_lsb_release_file(lsb_release_filename)
+    else:
+        dist_id, desc, release, code_name, _ = lsb_info.decode().split("\n")
+
+        return {
+            "distributor-id": dist_id,
+            "release": release,
+            "code-name": code_name,
+            "description": desc,
+        }
+
+
+def parse_lsb_release_file(filename):
+    """
+    Returns a C{dict} holding information about the system LSB release
+    by attempting to parse C{filename}.
+
+    @raises: A FileNotFoundError if C{filename} does not exist.
     """
     info = {}
-    for key in LSB_RELEASE_INFO_KEYS:
-        value = subprocess.check_output([LSB_RELEASE_FILENAME] + [LSB_RELEASE_INFO_KEYS[key.strip()]])
-        info[key.strip()] = value.strip().strip('"')
+
+    with open(filename) as fd:
+        for line in fd:
+            key, value = line.split("=")
+
+            if key in LSB_RELEASE_FILE_KEYS:
+                key = LSB_RELEASE_FILE_KEYS[key.strip()]
+                value = value.strip().strip('"')
+                info[key] = value
+
     return info

--- a/landscape/lib/lsb_release.py
+++ b/landscape/lib/lsb_release.py
@@ -1,26 +1,19 @@
-"""Get information from /etc/lsb_release."""
+"""Get information from /usr/bin/lsb_release."""
 
-LSB_RELEASE_FILENAME = "/etc/lsb-release"
-LSB_RELEASE_INFO_KEYS = {"DISTRIB_ID": "distributor-id",
-                         "DISTRIB_DESCRIPTION": "description",
-                         "DISTRIB_RELEASE": "release",
-                         "DISTRIB_CODENAME": "code-name"}
+LSB_RELEASE_FILENAME = "/usr/bin/lsb_release"
+LSB_RELEASE_INFO_KEYS = {"distributor-id": "-si",
+                         "release": "-sr",
+                         "code-name": "-sc",
+                         "description": "-sd"}
 
+import subprocess
 
 def parse_lsb_release(lsb_release_filename):
     """Return a C{dict} holding information about the system LSB release.
-
-    @raises: An IOError exception if C{lsb_release_filename} could not be read.
+    @raises: An OSError exception if C{lsb_release_filename} does not exist.
     """
-    fd = open(lsb_release_filename, "r")
     info = {}
-    try:
-        for line in fd:
-            key, value = line.split("=")
-            if key in LSB_RELEASE_INFO_KEYS:
-                key = LSB_RELEASE_INFO_KEYS[key.strip()]
-                value = value.strip().strip('"')
-                info[key] = value
-    finally:
-        fd.close()
+    for key in LSB_RELEASE_INFO_KEYS:
+        value = subprocess.check_output([LSB_RELEASE_FILENAME] + [LSB_RELEASE_INFO_KEYS[key.strip()]])
+        info[key.strip()] = value.strip().strip('"')
     return info

--- a/landscape/lib/lsb_release.py
+++ b/landscape/lib/lsb_release.py
@@ -23,7 +23,7 @@ def parse_lsb_release(lsb_release_filename=None):
 
     try:
         lsb_info = check_output([LSB_RELEASE, "-as"], stderr=DEVNULL)
-    except CalledProcessError:
+    except (CalledProcessError, FileNotFoundError):
         # Fall back to reading file, even if it doesn't exist.
         return parse_lsb_release_file(lsb_release_filename)
     else:

--- a/landscape/lib/lsb_release.py
+++ b/landscape/lib/lsb_release.py
@@ -28,10 +28,10 @@ def parse_lsb_release(lsb_release_filename=None):
             # Fall back to reading file, even if it doesn't exist.
             return parse_lsb_release_file(lsb_release_filename)
         else:
-            dist_id, desc, release, code_name, _ = lsb_info.decode().split("\n")
+            dist, desc, release, code_name, _ = lsb_info.decode().split("\n")
 
             return {
-                "distributor-id": dist_id,
+                "distributor-id": dist,
                 "release": release,
                 "code-name": code_name,
                 "description": desc,

--- a/landscape/lib/lsb_release.py
+++ b/landscape/lib/lsb_release.py
@@ -1,6 +1,6 @@
 """Get information from /usr/bin/lsb_release."""
 import os
-from subprocess import DEVNULL, CalledProcessError, check_output
+from subprocess import CalledProcessError, check_output
 
 LSB_RELEASE = "/usr/bin/lsb_release"
 LSB_RELEASE_FILENAME = "/etc/lsb_release"
@@ -21,20 +21,21 @@ def parse_lsb_release(lsb_release_filename=None):
     if lsb_release_filename and os.path.exists(lsb_release_filename):
         return parse_lsb_release_file(lsb_release_filename)
 
-    try:
-        lsb_info = check_output([LSB_RELEASE, "-as"], stderr=DEVNULL)
-    except (CalledProcessError, FileNotFoundError):
-        # Fall back to reading file, even if it doesn't exist.
-        return parse_lsb_release_file(lsb_release_filename)
-    else:
-        dist_id, desc, release, code_name, _ = lsb_info.decode().split("\n")
+    with open(os.devnull, 'w') as FNULL:
+        try:
+            lsb_info = check_output([LSB_RELEASE, "-as"], stderr=FNULL)
+        except (CalledProcessError, FileNotFoundError):
+            # Fall back to reading file, even if it doesn't exist.
+            return parse_lsb_release_file(lsb_release_filename)
+        else:
+            dist_id, desc, release, code_name, _ = lsb_info.decode().split("\n")
 
-        return {
-            "distributor-id": dist_id,
-            "release": release,
-            "code-name": code_name,
-            "description": desc,
-        }
+            return {
+                "distributor-id": dist_id,
+                "release": release,
+                "code-name": code_name,
+                "description": desc,
+            }
 
 
 def parse_lsb_release_file(filename):


### PR DESCRIPTION
As requested in Bug #1990268 here is some code that should replace the /etc/lsb-release dependency (which is Ubuntu-specific) with more generic /usr/bin/lsb_release dependency, allowing package reporting to work on Debian.

Looking through the code there are various references in the tests - I'm afraid this is beyond my skills, but hoping someone with more knowledge might be able to help out here!