### PR TITLE
Round load average to 2 decimal places

### DIFF
--- a/landscape/sysinfo/load.py
+++ b/landscape/sysinfo/load.py
@@ -9,5 +9,6 @@ class Load(object):
         self._sysinfo = sysinfo
 
     def run(self):
-        self._sysinfo.add_header("System load", str(round(os.getloadavg()[0], 2)))
+        self._sysinfo.add_header(
+            "System load", str(round(os.getloadavg()[0], 2)))
         return succeed(None)

--- a/landscape/sysinfo/load.py
+++ b/landscape/sysinfo/load.py
@@ -9,5 +9,5 @@ class Load(object):
         self._sysinfo = sysinfo
 
     def run(self):
-        self._sysinfo.add_header("System load", str(os.getloadavg()[0]))
+        self._sysinfo.add_header("System load", str(round(os.getloadavg()[0], 2)))
         return succeed(None)


### PR DESCRIPTION
More recent kernels (e.g. 5.15 in Ubuntu 22) seem to give many more than the 2 digits of precision that older ones (e.g. 5.4 in Ubuntu 20) gave in the return from getloadavg().
This restores the backwards compatibility and prevents silly things like this from landscape-sysinfo:
System load: 0.080078125   Processes: 124