### PR TITLE
Mention check3 and linting in README for contributors

### DIFF
--- a/README
+++ b/README
@@ -50,3 +50,9 @@ system bus.
 ```
 $ sudo ./scripts/landscape-client -c root-client.conf
 ```
+
+Before opening a PR, make sure to run the full testsuite and lint
+```
+make check3
+make lint
+```


### PR DESCRIPTION
We get a few PRs that fail the PR checks (usually on lint). We can lessen how many of these we get by at least _mentioning_ that contributors can run `check3` and `lint` locally before they create a PR.