### PR TITLE
Remove deprecated apt-key to stop gpg warning (LP: #1973202)

### DIFF
--- a/debian/landscape-client.postrm
+++ b/debian/landscape-client.postrm
@@ -18,6 +18,7 @@ case "$1" in
     purge)
     LOG_DIR=/var/log/landscape
     DATA_DIR=/var/lib/landscape
+    GPG_DIR=/etc/apt/trusted.gpg.d
 
     rm -f "/etc/default/landscape-client"
 
@@ -27,6 +28,8 @@ case "$1" in
     rm -f "${LOG_DIR}/watchdog.log"*
     rm -f "${LOG_DIR}/package-reporter.log"*
     rm -f "${LOG_DIR}/package-changer.log"*
+
+    rm -f "${GPG_DIR}/landscape-server"*.asc
 
     rm -rf "${DATA_DIR}/client"
     rm -rf "${DATA_DIR}/.gnupg"

--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -164,9 +164,10 @@ class AptFacade(object):
         self._dpkg_status = os.path.join(dpkg_dir, "status")
         if not os.path.exists(self._dpkg_status):
             create_text_file(self._dpkg_status, "")
-        # Apt will fail if it does not have a keyring.  It does not care if
-        # the keyring is empty.
-        touch_file(os.path.join(apt_dir, "trusted.gpg"))
+        # Apt will fail if it does not have a keyring. It does not care if
+        # the keyring is empty. (Do not create one if dir exists LP: #1973202)
+        if not os.path.isdir(os.path.join(apt_dir, "trusted.gpg.d")):
+            touch_file(os.path.join(apt_dir, "trusted.gpg"))
 
     def _ensure_sub_dir(self, sub_dir):
         """Ensure that a dir in the Apt root exists."""


### PR DESCRIPTION
Manual testing instructions:

1) Register client to on prem server
2) Follow steps to set up mirror (use restricted component to limit file size) all the way to "Associate computers with repository profile" making sure to associate the profile with the registered client https://docs.ubuntu.com/landscape/en/repositories
3) Look in /etc/apt/trusted.gpg.d for the keys and confirm no 'trusted.gpg' file gets created