### PR TITLE
Separate bytes-handling for python2 and python3

### DIFF
--- a/landscape/lib/schema.py
+++ b/landscape/lib/schema.py
@@ -1,4 +1,5 @@
 """A schema system. Yes. Another one!"""
+import six
 from twisted.python.compat import iteritems, unicode, long
 
 
@@ -65,12 +66,24 @@ class Float(object):
 
 
 class Bytes(object):
-    """A binary string."""
+    """A binary string.
+
+    If the value is a Python3 str (unicode), it will be automatically
+    encoded.
+    """
     def coerce(self, value):
-        if isinstance(value, str):
-            return value.encode()
-        if not isinstance(value, bytes):
-            raise InvalidError("%r isn't a bytestring" % (value,))
+        error_msg = "%r isn't a bytestring" % value
+
+        if six.PY2:
+            if not isinstance(value, str):
+                raise InvalidError(error_msg)
+        else:  # six.PY3
+            if not isinstance(value, (str, bytes)):
+                raise InvalidError(error_msg)
+
+            if isinstance(value, str):
+                return value.encode()
+
         return value
 
 

--- a/landscape/lib/schema.py
+++ b/landscape/lib/schema.py
@@ -1,5 +1,4 @@
 """A schema system. Yes. Another one!"""
-import six
 from twisted.python.compat import iteritems, unicode, long
 
 
@@ -72,19 +71,13 @@ class Bytes(object):
     encoded.
     """
     def coerce(self, value):
-        error_msg = "%r isn't a bytestring" % value
+        if isinstance(value, bytes):
+            return value
 
-        if six.PY2:
-            if not isinstance(value, str):
-                raise InvalidError(error_msg)
-        else:  # six.PY3
-            if not isinstance(value, (str, bytes)):
-                raise InvalidError(error_msg)
+        if isinstance(value, str):
+            return value.encode()
 
-            if isinstance(value, str):
-                return value.encode()
-
-        return value
+        raise InvalidError("%r isn't a bytestring" % value)
 
 
 class Unicode(object):


### PR DESCRIPTION
This patch separates the coercion of bytes-type schema data in py2 from py3. The py2 behaviour keeps the previous behaviour of raising an exception if the data is not bytes, but the py3 behavious will encode the data as bytes if it is a py3 unicode str.