### PR TITLE
Coerce bytestring Contants to string Constants

### DIFF
--- a/landscape/lib/schema.py
+++ b/landscape/lib/schema.py
@@ -13,6 +13,12 @@ class Constant(object):
         self.value = value
 
     def coerce(self, value):
+        if isinstance(self.value, str) and isinstance(value, bytes):
+            try:
+                value = value.decode()
+            except UnicodeDecodeError:
+                pass
+
         if value != self.value:
             raise InvalidError("%r != %r" % (value, self.value))
         return value

--- a/landscape/message_schemas/test_message.py
+++ b/landscape/message_schemas/test_message.py
@@ -1,6 +1,6 @@
 import unittest
 
-from landscape.lib.schema import Int
+from landscape.lib.schema import Constant, Int
 from landscape.message_schemas.message import Message
 
 
@@ -12,6 +12,14 @@ class MessageTest(unittest.TestCase):
         self.assertEqual(
             schema.coerce({"type": "foo", "data": 3}),
             {"type": "foo", "data": 3})
+
+    def test_coerce_bytes_to_str(self):
+        """
+        The L{Constant} schema type recognizes bytestrings that decode to
+        matching strings.
+        """
+        constant = Constant("register")
+        self.assertEqual(constant.coerce(b"register"), "register")
 
     def test_timestamp(self):
         """L{Message} schemas should accept C{timestamp} keys."""


### PR DESCRIPTION
This patch addresses https://bugs.launchpad.net/landscape/+bug/2003349 by ensuring that messages sent by earlier versions of landscape-client that use bytestrings for Constant values are coerced to strings when interpreted.