### PR TITLE
1989968 wrong monitor plugins option in example

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -77,7 +77,6 @@ ignore_sigusr1 = False
 #
 #   ActiveProcessInfo - lists active processes
 #   ComputerInfo - various information
-#   HardwareInventory - information provided by the "lshw" command
 #   LoadAverage - load information
 #   MemoryInfo - memory information
 #   MountInfo - information about mount points (space available, used)


### PR DESCRIPTION
Resolves [Bug #1989968](https://bugs.launchpad.net/landscape-client/+bug/1989968).

- The HardwareInventory plugin was removed from `example.conf`
- When invalid plugins are specified, a warning is emitted and that plugin is skipped. Prior, the application would crash.