### PR TITLE
Test for broken control file (LP: #1813442)

### DIFF
--- a/landscape/lib/apt/package/testing.py
+++ b/landscape/lib/apt/package/testing.py
@@ -183,6 +183,7 @@ PKGNAME_SIMPLE_RELATIONS = "simple-relations_1.0_all.deb"
 PKGNAME_VERSION_RELATIONS = "version-relations_1.0_all.deb"
 PKGNAME_MULTIPLE_RELATIONS = "multiple-relations_1.0_all.deb"
 PKGNAME_OR_RELATIONS = "or-relations_1.0_all.deb"
+PKGNAME_BROKEN_DESCRIPTION = "brokendescription_1.0_all.deb"
 
 PKGDEB1 = (
     b"ITxhcmNoPgpkZWJpYW4tYmluYXJ5ICAgMTE2NjExNDQ5MyAgMCAgICAgMCAgICAgMT"
@@ -356,6 +357,19 @@ PKGDEB_OR_RELATIONS = (
     b"1/9yNK"
     b"GadWR2ltRC651hGpxw4et/u8phTny3Vdfvy2dgAAAAAAAAAAANjRE6Lr2rEAKAAACg=="
 )
+PKGDEB_BROKEN_DESCRIPTION = (
+    b"ITxhcmNoPgpkZWJpYW4tYmluYXJ5ICAgMTY3OTIzNzM2MyAgMCAgICAgMCAgICAgMTAwNj"
+    b"Q0ICA0ICAgICAgICAgYAoyLjAKY29udHJvbC50YXIuenN0IDE2NzkyMzczNjMgIDAgICAg"
+    b"IDAgICAgIDEwMDY0NCAgMjY4ICAgICAgIGAKKLUv/QBoHQgAwk4uInBJ21bxEmhb1HK7ih"
+    b"shSQan5wcgNCga0N2kn+wSVP33XwppIIeGBx1QBNf1M9H1XWE3fk4z9afsrX5H3l+GtZlz"
+    b"e4+y5nUOhExsDOqo26a91qhCFwIjoHFGy9YXGwUUALQ1b58CXb7ja2tgOLf/RO7YGH6FkZ"
+    b"DSBX4jGM9bdNozbPZ6wX+hSyfsAu9B0kzUoVTKxFLKOtZKnH98zgiU0f1T9TfCJxPRRJSi"
+    b"HCmRIGktlSkRREmJQAEcILBKRqwcAxUD8QEAkmWFeAkIIKSmWvDwQBNwfBxuFeZKr7/ACR"
+    b"VYL8ABU/3amMvgAU33hMJwAGz/tzlrw2MACcQUwHyabmRhdGEudGFyLnpzdCAgICAxNjc5"
+    b"MjM3MzYzICAwICAgICAwICAgICAxMDA2NDQgIDg0ICAgICAgICBgCii1L/0AaF0CADQDLi"
+    b"8AMDc1NTE3NTEAMTQ0MDU1NjU3NDcAMDEwNTcwACA1AAB1c3RhciAgAGJyMHRoM3IACSCQ"
+    b"mwfMBhyGBqrXn71BlmwNcH3CQw=="
+)
 
 
 HASH1 = base64.decodebytes(b"/ezv4AefpJJ8DuYFSq4RiEHJYP4=")
@@ -373,6 +387,9 @@ HASH_MULTIPLE_RELATIONS = (
 )
 HASH_OR_RELATIONS = (
     b"\xa1q\xf4*\x1c\xd4L\xa1\xca\xf1\xfa?\xc3\xc7\x9f\x88\xd53B\xc9"
+)
+HASH_BROKEN_DESCRIPTION = (
+    b"\x16\xbd\xb8+\xed\xc0\x07\x84f!\xe6d\xea\xe7\xaf\xc6\xe4\t\xad\xd7"
 )
 
 

--- a/landscape/lib/apt/package/tests/test_skeleton.py
+++ b/landscape/lib/apt/package/tests/test_skeleton.py
@@ -22,11 +22,13 @@ from landscape.lib.apt.package.testing import HASH_MULTIPLE_RELATIONS
 from landscape.lib.apt.package.testing import HASH_OR_RELATIONS
 from landscape.lib.apt.package.testing import HASH_SIMPLE_RELATIONS
 from landscape.lib.apt.package.testing import HASH_VERSION_RELATIONS
+from landscape.lib.apt.package.testing import PKGDEB_BROKEN_DESCRIPTION
 from landscape.lib.apt.package.testing import PKGDEB_MINIMAL
 from landscape.lib.apt.package.testing import PKGDEB_MULTIPLE_RELATIONS
 from landscape.lib.apt.package.testing import PKGDEB_OR_RELATIONS
 from landscape.lib.apt.package.testing import PKGDEB_SIMPLE_RELATIONS
 from landscape.lib.apt.package.testing import PKGDEB_VERSION_RELATIONS
+from landscape.lib.apt.package.testing import PKGNAME_BROKEN_DESCRIPTION
 from landscape.lib.apt.package.testing import PKGNAME_MINIMAL
 from landscape.lib.apt.package.testing import PKGNAME_MULTIPLE_RELATIONS
 from landscape.lib.apt.package.testing import PKGNAME_OR_RELATIONS
@@ -64,6 +66,11 @@ class SkeletonTestHelper:
             test_case.skeleton_repository_dir,
             PKGNAME_OR_RELATIONS,
             PKGDEB_OR_RELATIONS,
+        )
+        create_deb(
+            test_case.skeleton_repository_dir,
+            PKGNAME_BROKEN_DESCRIPTION,
+            PKGDEB_BROKEN_DESCRIPTION,
         )
 
 
@@ -146,6 +153,14 @@ class SkeletonAptTest(BaseTestCase):
         self.assertTrue(isinstance(skeleton.name, unicode))
         self.assertTrue(isinstance(skeleton.version, unicode))
         self.assertEqual(HASH1, skeleton.get_hash())
+
+    def test_build_skeleton_with_broken_description(self):
+        """
+        A package that has only the required fields and a broken description.
+        """
+        brokendescription_package = self.get_package("brokendescription")
+        with self.assertRaises(UnicodeDecodeError):
+            build_skeleton_apt(brokendescription_package)
 
     def test_build_skeleton_with_info(self):
         """


### PR DESCRIPTION
This is a test to reproduce the bug reported at [LP: #1813442](https://bugs.launchpad.net/landscape-client/+bug/1813442) :

```
landscape.lib.apt.package.tests.test_skeleton
  SkeletonAptTest
    test_build_skeleton_broken_description ...                          [ERROR]

===============================================================================
[ERROR]
Traceback (most recent call last):
  File "/usr/lib/python3.10/unittest/case.py", line 59, in testPartExecutor
    yield
  File "/usr/lib/python3.10/unittest/case.py", line 591, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.10/unittest/case.py", line 549, in _callTestMethod
    method()
  File ".../landscape-client/landscape/lib/apt/package/tests/test_skeleton.py", line 340, in test_build_skeleton_broken_description
    skeleton = build_skeleton_apt(brokendescription_package)
  File ".../landscape-client/landscape/lib/apt/package/skeleton.py", line 136, in build_skeleton_apt
    parse_record_field(version.record, "Provides", DEB_PROVIDES),
  File "/usr/lib/python3/dist-packages/apt/package.py", line 671, in record
    return Record(self._records.record)
builtins.UnicodeDecodeError: 'utf-8' codec can't decode byte 0x96 in position 427: invalid start byte

landscape.lib.apt.package.tests.test_skeleton.SkeletonAptTest.test_build_skeleton_broken_description
-------------------------------------------------------------------------------
Ran 1 tests in 0.223s

FAILED (errors=1)
```

This test checks that Landscape fails with the reported UnicodeDecodeError just in case the Landscape team decides to manage this situation differently.