### PR TITLE
Changed the way Dependency data is readen (LP: #1813442)

### DIFF
--- a/landscape/lib/apt/package/facade.py
+++ b/landscape/lib/apt/package/facade.py
@@ -265,15 +265,15 @@ class AptFacade:
             if not self._is_main_architecture(package):
                 continue
             for version in package.versions:
-                hash = self.get_package_skeleton(
+                skeleton_hash = self.get_package_skeleton(
                     version,
                     with_info=False,
                 ).get_hash()
                 # Use a tuple including the package, since the Version
                 # objects of two different packages can have the same
                 # hash.
-                self._pkg2hash[(package, version)] = hash
-                self._hash2pkg[hash] = version
+                self._pkg2hash[(package, version)] = skeleton_hash
+                self._hash2pkg[skeleton_hash] = version
         self._channels_loaded = True
 
     def ensure_channels_reloaded(self):

--- a/landscape/lib/apt/package/tests/test_skeleton.py
+++ b/landscape/lib/apt/package/tests/test_skeleton.py
@@ -159,8 +159,7 @@ class SkeletonAptTest(BaseTestCase):
         A package that has only the required fields and a broken description.
         """
         brokendescription_package = self.get_package("brokendescription")
-        with self.assertRaises(UnicodeDecodeError):
-            build_skeleton_apt(brokendescription_package)
+        build_skeleton_apt(brokendescription_package)
 
     def test_build_skeleton_with_info(self):
         """


### PR DESCRIPTION
I got deeper into this problem and found that it was happening because we were using "version.record" which is the source of the failure.

Since we don't want to mess up with the UnicodeDecodeError still happening in the apt package, I  decided to switch the way the dependencies information is readen from the package, and I removed "version.record" from the code so it doesn't try to parse the broken data anymore.

Also, I discovered in the original source code that "PreDepends" was empty in all my tests. Now it has information as I think it should work. I would like somebody to check my solution in search of some collateral problems with the new "PreDepends".

I also renamed a variable "hash" in facade to "hash_skeleton".

