### PR TITLE
send ubuntu pro reboot output

### DIFF
--- a/example.conf
+++ b/example.conf
@@ -85,9 +85,17 @@ ignore_sigusr1 = False
 #   PackageMonitor - packages installed, available, versions
 #   UserMonitor - users, groups
 #   RebootRequired - whether a reboot is required or not
+#   AptPreferences - system APT preferences configuration
 #   NetworkActivity - network information (TX, RX)
 #   NetworkDevice - a list of connected network devices
 #   UpdateManager - controls when distribution upgrades are prompted
+#   CPUUsage - CPU usage information
+#   SwiftUsage - Swift cluster usage
+#   CephUsage - Ceph usage information
+#   ComputerTags - changes in computer tags
+#   UbuntuProInfo - Ubuntu Pro registration information
+#   LivePatch - Livepath status information
+#   UbuntuProRebootRequired - informs if the system needs to be rebooted
 #
 # The special value "ALL" is an alias for the full list of plugins.
 monitor_plugins = ALL

--- a/landscape/client/monitor/config.py
+++ b/landscape/client/monitor/config.py
@@ -22,6 +22,7 @@ ALL_PLUGINS = [
     "ComputerTags",
     "UbuntuProInfo",
     "LivePatch",
+    "UbuntuProRebootRequired",
 ]
 
 

--- a/landscape/client/monitor/tests/test_ubuntuprorebootrequired.py
+++ b/landscape/client/monitor/tests/test_ubuntuprorebootrequired.py
@@ -1,0 +1,29 @@
+from landscape.client.monitor.ubuntuprorebootrequired import (
+    UbuntuProRebootRequired,
+)
+from landscape.client.tests.helpers import LandscapeTest, MonitorHelper
+
+
+class UbuntuProRebootRequiredTest(LandscapeTest):
+    """Ubuntu Pro required plugin tests."""
+
+    helpers = [MonitorHelper]
+
+    def setUp(self):
+        super().setUp()
+        self.mstore.set_accepted_types(["ubuntu-pro-reboot-required"])
+
+    def test_ubuntu_pro_reboot_required(self):
+        """Tests calling reboot required."""
+
+        plugin = UbuntuProRebootRequired()
+        self.monitor.add(plugin)
+        plugin.exchange()
+
+        messages = self.mstore.get_pending_messages()
+
+        self.assertGreater(len(messages), 0)
+        self.assertIn("ubuntu-pro-reboot-required", messages[0])
+        self.assertIn(
+            "reboot_required", messages[0]["ubuntu-pro-reboot-required"]
+        )

--- a/landscape/client/monitor/ubuntuprorebootrequired.py
+++ b/landscape/client/monitor/ubuntuprorebootrequired.py
@@ -1,0 +1,25 @@
+from uaclient.api.u.pro.security.status.reboot_required.v1 import reboot_required
+
+from landscape.client.monitor.plugin import DataWatcher
+
+
+class UbuntuProRebootRequired(DataWatcher):
+    """
+    Plugin that captures and reports Ubuntu Pro reboot required information.
+    The `uaclient` Python API should be installed by default.
+    """
+    
+    message_type = "ubuntu-pro-reboot-required"
+    message_key = message_type
+    persist_name = message_type
+    scope = "ubuntu-pro"
+    run_immediately = True
+    run_interval = 900    # 15 minutes
+
+    def get_data(self):
+        """
+        Return the JSON formatted output of "reboot-required" from Ubuntu Pro 
+        API.
+        """
+
+        return reboot_required().to_json()

--- a/landscape/client/monitor/ubuntuprorebootrequired.py
+++ b/landscape/client/monitor/ubuntuprorebootrequired.py
@@ -1,24 +1,26 @@
-from uaclient.api.u.pro.security.status.reboot_required.v1 import reboot_required
+from uaclient.api.u.pro.security.status.reboot_required.v1 import (
+    reboot_required,
+)
 
 from landscape.client.monitor.plugin import DataWatcher
 
 
 class UbuntuProRebootRequired(DataWatcher):
     """
-    Plugin that captures and reports Ubuntu Pro reboot required information.
-    The `uaclient` Python API should be installed by default.
+    Plugin that captures and reports from Ubuntu Pro API if the system needs to
+    be rebooted. The `uaclient` Python API should be installed by default.
     """
-    
+
     message_type = "ubuntu-pro-reboot-required"
     message_key = message_type
     persist_name = message_type
     scope = "ubuntu-pro"
     run_immediately = True
-    run_interval = 900    # 15 minutes
+    run_interval = 900  # 15 minutes
 
     def get_data(self):
         """
-        Return the JSON formatted output of "reboot-required" from Ubuntu Pro 
+        Return the JSON formatted output of "reboot-required" from Ubuntu Pro
         API.
         """
 

--- a/landscape/message_schemas/server_bound.py
+++ b/landscape/message_schemas/server_bound.py
@@ -58,6 +58,7 @@ __all__ = [
     "COMPUTER_TAGS",
     "UBUNTU_PRO_INFO",
     "LIVEPATCH",
+    "UBUNTU_PRO_REBOOT_REQUIRED",
 ]
 
 
@@ -751,6 +752,11 @@ LIVEPATCH = Message(
     "livepatch",
     {"livepatch": Unicode()})
 
+UBUNTU_PRO_REBOOT_REQUIRED = Message(
+    "ubuntu-pro-reboot-required",
+    {"ubuntu-pro-reboot-required": Unicode()},
+)
+
 message_schemas = (
     ACTIVE_PROCESS_INFO,
     COMPUTER_UPTIME,
@@ -796,4 +802,5 @@ message_schemas = (
     COMPUTER_TAGS,
     UBUNTU_PRO_INFO,
     LIVEPATCH,
+    UBUNTU_PRO_REBOOT_REQUIRED,
 )


### PR DESCRIPTION
- Adds a monitor plugin to check if a reboot is required
- Update documentation on available plugins