### PR TITLE
make manage_sources_list_d conf-file-only

### DIFF
--- a/landscape/client/deployment.py
+++ b/landscape/client/deployment.py
@@ -151,13 +151,6 @@ class Configuration(BaseConfiguration):
             help="Ratio, between 0 and 1, by which to stagger "
             "various tasks of landscape.",
         )
-        parser.add_option(
-            "--manage-sources-list-d",
-            action="store_true",
-            default=True,
-            help="Repository profiles manage the files in "
-            "/etc/apt/sources.list.d",
-        )
 
         # Hidden options, used for load-testing to run in-process clones
         parser.add_option("--clones", default=0, type=int, help=SUPPRESS_HELP)

--- a/landscape/client/manager/aptsources.py
+++ b/landscape/client/manager/aptsources.py
@@ -133,7 +133,12 @@ class AptSources(ManagerPlugin):
             if os.path.isfile(saved_sources):
                 shutil.move(saved_sources, self.SOURCES_LIST)
 
-        if self.registry.config.manage_sources_list_d not in FALSE_VALUES:
+        manage_sources_list_d = getattr(
+            self.registry.config,
+            "manage_sources_list_d",
+            True,
+        )
+        if manage_sources_list_d not in FALSE_VALUES:
             filenames = glob.glob(os.path.join(self.SOURCES_LIST_D, "*.list"))
             for filename in filenames:
                 shutil.move(filename, f"{filename}.save")

--- a/landscape/client/tests/test_deployment.py
+++ b/landscape/client/tests/test_deployment.py
@@ -122,11 +122,6 @@ class BaseConfigurationTest(LandscapeTest):
         self.config.load([])
         self.assertEqual(self.config.whatever, "yay")
 
-    def test_manage_sources_list_d(self):
-        self.write_config_file(manage_sources_list_d="False")
-        self.config.reload()
-        self.assertEqual(self.config.manage_sources_list_d, "False")
-
     # CLI options
 
     def test_config_file_default(self):


### PR DESCRIPTION
There's some really weird interactions going on with the default CLI param value and the value in the config file. To reduce the impact, I've decided that this config will be only in the conf file until we upgrade our configparser and argparser issues.