### PR TITLE
Limit message data directory size

### DIFF
--- a/landscape/client/broker/store.py
+++ b/landscape/client/broker/store.py
@@ -312,14 +312,14 @@ class MessageStore:
         Delete messages dirs if there's any over the max, which happens if
         messages are queued up but not able to be sent
         """
-            
+
         cur_dirs = os.listdir(self._directory)
         cur_dirs.sort(key=int)  # Since you could have 0, .., 9, 10
         num_dirs = len(cur_dirs)
 
         num_dirs_to_delete = max(0, num_dirs - self._max_dirs)  # No negatives
         dirs_to_delete = cur_dirs[:num_dirs_to_delete]  # Chop off beginning
-        
+
         for dirname in dirs_to_delete:
             dirpath = os.path.join(self._directory, dirname)
             try:
@@ -329,7 +329,7 @@ class MessageStore:
                 logging.warning(traceback.format_exc())
                 logging.warning("Unable to delete message directory!")
                 logging.warning(dirpath)
-            
+
         # Something is wrong if after deleting a bunch of files, we are still
         # using too much space. Rather then look around for big files, we just
         # start over.

--- a/landscape/client/broker/store.py
+++ b/landscape/client/broker/store.py
@@ -137,7 +137,8 @@ class MessageStore:
     # in case the server supports it.
     _api = DEFAULT_SERVER_API
 
-    def __init__(self, persist, directory, directory_size=1000, max_dirs=4, max_size_mb=400):
+    def __init__(self, persist, directory, directory_size=1000, max_dirs=4,
+                 max_size_mb=400):
         self._directory = directory
         self._directory_size = directory_size
         self._max_dirs = max_dirs  # Maximum number of directories in store
@@ -297,7 +298,7 @@ class MessageStore:
                 else:
                     messages.append(message)
         return messages
-    
+
     def get_messages_total_size(self):
         """Get total size of messages directory"""
         sizes = []

--- a/landscape/client/broker/tests/test_store.py
+++ b/landscape/client/broker/tests/test_store.py
@@ -137,6 +137,85 @@ class MessageStoreTest(LandscapeTest):
         self.assertEqual(self.store.get_pending_offset(), 0)
         self.assertEqual(self.store.get_pending_messages(), [])
 
+    def test_messages_over_limit(self):
+        """
+        Create six messages, two per directory. Since there is a limit of 
+        one directory then only the last 2 messages should be in the queue
+        """
+    
+        self.store._directory_size = 2
+        self.store._max_dirs = 1
+        for num in range(6):  # 0,1  2,3  4,5
+            message = {"type": "data", "data": f"{num}".encode()}
+            self.store.add(message)
+        messages = self.store.get_pending_messages(200)
+        self.assertMessages(
+            messages,
+            [{"type": "data", "data": b"4"},
+             {"type": "data", "data": b"5"}],
+        )
+        
+
+    def test_messages_under_limit(self):
+        """
+        Create six messages, all of which should be in the queue, since 3 
+        directories are active
+        """
+    
+        self.store._directory_size = 2
+        self.store._max_dirs = 3
+        messages_sent = []
+        for num in range(6):  # 0,1  2,3  4,5
+            message = {"type": "data", "data": f"{num}".encode()}
+            messages_sent.append(message)
+            self.store.add(message)
+        messages = self.store.get_pending_messages(200)
+        self.assertMessages(
+            messages,
+            messages_sent
+        )
+        
+    def test_messages_over_mb(self):
+        """
+        Create three messages with the second one being very large. The 
+        max size should get triggered, so all should be cleared except for the
+        last one.
+        """
+    
+        self.store._directory_size = 2
+        self.store._max_size_mb = 0.01
+        self.store.add({"type": "data", "data": b"a"})
+        self.store.add({"type": "data", "data": b"b"*15000})
+        self.store.add({"type": "data", "data": b"c"})
+        messages = self.store.get_pending_messages(200)
+        self.assertMessages(
+            messages,
+            [
+             {"type": "data", "data": b"c"}],
+        )
+        
+    @mock.patch("shutil.rmtree")
+    def test_exception_on_message_limit(self, rmtree_mock):
+        """
+        If an exception occurs while deleting it shouldn't affect the next 
+        message sent
+        """
+        rmtree_mock.side_effect = IOError("Error!")
+        self.store._directory_size = 1
+        self.store._max_dirs = 1
+        self.store.add({"type": "data", "data": b"a"})
+        self.store.add({"type": "data", "data": b"b"})
+        self.store.add({"type": "data", "data": b"c"})
+        messages = self.store.get_pending_messages(200)
+
+        self.assertMessages(
+            messages,
+            [
+        {"type": "data", "data": b"a"},
+        {"type": "data", "data": b"b"},
+        {"type": "data", "data": b"c"},          ],
+        )
+
     def test_one_message(self):
         self.store.add(dict(type="data", data=b"A thing"))
         messages = self.store.get_pending_messages(200)

--- a/landscape/client/broker/tests/test_store.py
+++ b/landscape/client/broker/tests/test_store.py
@@ -139,10 +139,10 @@ class MessageStoreTest(LandscapeTest):
 
     def test_messages_over_limit(self):
         """
-        Create six messages, two per directory. Since there is a limit of 
+        Create six messages, two per directory. Since there is a limit of
         one directory then only the last 2 messages should be in the queue
         """
-    
+
         self.store._directory_size = 2
         self.store._max_dirs = 1
         for num in range(6):  # 0,1  2,3  4,5
@@ -151,17 +151,15 @@ class MessageStoreTest(LandscapeTest):
         messages = self.store.get_pending_messages(200)
         self.assertMessages(
             messages,
-            [{"type": "data", "data": b"4"},
-             {"type": "data", "data": b"5"}],
+            [{"type": "data", "data": b"4"}, {"type": "data", "data": b"5"}],
         )
-        
 
     def test_messages_under_limit(self):
         """
-        Create six messages, all of which should be in the queue, since 3 
+        Create six messages, all of which should be in the queue, since 3
         directories are active
         """
-    
+
         self.store._directory_size = 2
         self.store._max_dirs = 3
         messages_sent = []
@@ -170,34 +168,30 @@ class MessageStoreTest(LandscapeTest):
             messages_sent.append(message)
             self.store.add(message)
         messages = self.store.get_pending_messages(200)
-        self.assertMessages(
-            messages,
-            messages_sent
-        )
-        
+        self.assertMessages(messages, messages_sent)
+
     def test_messages_over_mb(self):
         """
-        Create three messages with the second one being very large. The 
+        Create three messages with the second one being very large. The
         max size should get triggered, so all should be cleared except for the
         last one.
         """
-    
+
         self.store._directory_size = 2
         self.store._max_size_mb = 0.01
         self.store.add({"type": "data", "data": b"a"})
-        self.store.add({"type": "data", "data": b"b"*15000})
+        self.store.add({"type": "data", "data": b"b" * 15000})
         self.store.add({"type": "data", "data": b"c"})
         messages = self.store.get_pending_messages(200)
         self.assertMessages(
             messages,
-            [
-             {"type": "data", "data": b"c"}],
+            [{"type": "data", "data": b"c"}],
         )
-        
+
     @mock.patch("shutil.rmtree")
     def test_exception_on_message_limit(self, rmtree_mock):
         """
-        If an exception occurs while deleting it shouldn't affect the next 
+        If an exception occurs while deleting it shouldn't affect the next
         message sent
         """
         rmtree_mock.side_effect = IOError("Error!")
@@ -211,9 +205,10 @@ class MessageStoreTest(LandscapeTest):
         self.assertMessages(
             messages,
             [
-        {"type": "data", "data": b"a"},
-        {"type": "data", "data": b"b"},
-        {"type": "data", "data": b"c"},          ],
+                {"type": "data", "data": b"a"},
+                {"type": "data", "data": b"b"},
+                {"type": "data", "data": b"c"},
+            ],
         )
 
     def test_one_message(self):


### PR DESCRIPTION
Manual testing instructions:

 1. Modify `directory_size` to be 10 instead of 1000 in the class `__init__` of `store.py`
 1. Change the "Sending payload" and "Received payload" to not print the payload in client/broker/transport.py. This makes reading the output logs easier (optional)
 1.  Connect this client to a server and accept the computer
 1. Either stop the server or stop client to make the message system unreachable (change message system config `url` to be something that doesn't exist. Just changing the url suffix should be sufficient)
 1. Start client and take a look at the `messages` directory which is inside of the `data-path` config and watch the directory grow (should not take long).  Once there are 4 folders in there observer the 5th one to get deleted (max_dirs is 4).  Note there may be a slight delay with the deletion since it doesn't happen until after the 5th directory is created. 
 1. To test the deletion by megabytes,  set the `max_size_mb` to something really small like 0.4 kb which is probably the size of the directory already